### PR TITLE
Arrange veteran call confirmation properties to correct section

### DIFF
--- a/src/components/main/veteran/__tests__/contact-info-section.test.js
+++ b/src/components/main/veteran/__tests__/contact-info-section.test.js
@@ -81,24 +81,7 @@ describe('ContactInfoSection', () => {
 
     expect(screen.getByText('Contact Information')).toBeInTheDocument();
     expect(screen.getByTestId('address-information-card')).toBeInTheDocument();
-    expect(screen.getByText('Call Center Information')).toBeInTheDocument();
     expect(screen.getByText('Emergency Contact')).toBeInTheDocument();
-  });
-
-  test('renders call center information fields', () => {
-    const { container } = render(
-      <TestWrapper defaultValues={{ call: { assigned_to: 'Staff', notes: 'Notes' } }}>
-        <ContactInfoSection 
-          errors={{}} 
-          veteran={mockVeteran}
-          onOpenHistory={mockOnOpenHistory}
-          onManagePairing={mockOnManagePairing}
-        />
-      </TestWrapper>
-    );
-
-    expect(container.querySelector('input[name="call.assigned_to"]')).toBeInTheDocument();
-    expect(container.querySelector('input[name="call.notes"]') || container.querySelector('textarea[name="call.notes"]')).toBeInTheDocument();
   });
 
   test('renders emergency contact fields', () => {
@@ -119,9 +102,6 @@ describe('ContactInfoSection', () => {
 
   test('displays error messages for contact fields', () => {
     const errors = {
-      call: {
-        assigned_to: { message: 'Assigned to is required' }
-      },
       emerg_contact: {
         name: { message: 'Name is required' }
       }
@@ -138,7 +118,6 @@ describe('ContactInfoSection', () => {
       </TestWrapper>
     );
 
-    expect(screen.getByText('Assigned to is required')).toBeInTheDocument();
     expect(screen.getByText('Name is required')).toBeInTheDocument();
   });
 

--- a/src/components/main/veteran/__tests__/essential-info-section.test.js
+++ b/src/components/main/veteran/__tests__/essential-info-section.test.js
@@ -72,7 +72,35 @@ describe('EssentialInfoSection', () => {
     expect(screen.getByTestId('personal-information-card')).toBeInTheDocument();
     expect(screen.getByText('Service Information')).toBeInTheDocument();
     expect(screen.getByText('Medical Information')).toBeInTheDocument();
+    expect(screen.getByText('Call Center Information')).toBeInTheDocument();
     expect(screen.getByText('Flight Status')).toBeInTheDocument();
+  });
+
+  test('renders call center information fields and confirmed date/by', () => {
+    const mockFlightOptions = [
+      { value: 'FL123', label: 'Flight 123', disabled: false },
+      { value: 'FL124', label: 'Flight 124', disabled: false },
+    ];
+    const mockVeteranWithCall = {
+      ...mockVeteran,
+      call: { assigned_to: 'Staff', notes: 'Notes', history: [] },
+    };
+    const { container } = render(
+      <TestWrapper defaultValues={{ call: { assigned_to: 'Staff', notes: 'Notes' }, flight: { confirmed_date: '', confirmed_by: '' } }}>
+        <EssentialInfoSection 
+          errors={{}} 
+          veteran={mockVeteranWithCall}
+          onOpenHistory={mockOnOpenHistory}
+          flightOptions={mockFlightOptions}
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('Call Center Information')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed Date')).toBeInTheDocument();
+    expect(screen.getByText('Confirmed By')).toBeInTheDocument();
+    expect(container.querySelector('input[name="call.assigned_to"]')).toBeInTheDocument();
+    expect(container.querySelector('input[name="call.notes"]') || container.querySelector('textarea[name="call.notes"]')).toBeInTheDocument();
   });
 
   test('renders service information fields', () => {

--- a/src/components/main/veteran/contact-info-section.js
+++ b/src/components/main/veteran/contact-info-section.js
@@ -16,11 +16,10 @@ import OutlinedInput from '@mui/material/OutlinedInput';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import { Phone, Headset, EnvelopeSimple, Users, MagnifyingGlass } from '@phosphor-icons/react';
+import { Phone, EnvelopeSimple, Users, MagnifyingGlass } from '@phosphor-icons/react';
 import { paths } from '@/paths';
 import { AddressInformationCard } from '@/components/main/shared/address-information-card';
 import { PairingInformationCard } from '@/components/main/shared/pairing-information-card';
-import { HistoryButton } from '@/components/main/shared/history-button';
 import { FormSectionHeader } from '@/components/main/shared/form-section-header';
 
 export function ContactInfoSection({ 
@@ -83,79 +82,6 @@ export function ContactInfoSection({
         emailGridProps={{ xs: 12, md: 4 }}
         disabled={disabled}
       />
-
-      {/* Call Center Information Card */}
-      <Card elevation={2}>
-        <CardContent>
-          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 3 }}>
-            <FormSectionHeader 
-              icon={Headset} 
-              title="Call Center Information" 
-            />
-            <HistoryButton
-              title="Call Center"
-              history={veteran?.call?.history || []}
-              onOpenHistory={onOpenHistory}
-            />
-          </Stack>
-          <Grid container spacing={3}>
-            <Grid xs={12} md={6}>
-              <Controller
-                control={control}
-                name="call.assigned_to"
-                render={({ field }) => (
-                  <FormControl error={Boolean(errors.call?.assigned_to)} fullWidth disabled={disabled}>
-                    <InputLabel>Call Assigned To</InputLabel>
-                    <OutlinedInput {...field} inputProps={{ maxLength: 30 }} />
-                    {errors.call?.assigned_to ? <FormHelperText>{errors.call.assigned_to.message}</FormHelperText> : null}
-                  </FormControl>
-                )}
-              />
-            </Grid>
-            <Grid xs={12}>
-              <Controller
-                control={control}
-                name="call.notes"
-                render={({ field }) => (
-                  <FormControl error={Boolean(errors.call?.notes)} fullWidth disabled={disabled}>
-                    <InputLabel>Call Center Notes</InputLabel>
-                    <OutlinedInput {...field} multiline rows={3} />
-                    {errors.call?.notes ? <FormHelperText>{errors.call.notes.message}</FormHelperText> : null}
-                  </FormControl>
-                )}
-              />
-            </Grid>
-            <Grid xs={12} md={6}>
-              <FormControlLabel
-                control={
-                  <Controller
-                    control={control}
-                    name="call.mail_sent"
-                    render={({ field }) => (
-                      <Checkbox {...field} checked={field.value} disabled={disabled} />
-                    )}
-                  />
-                }
-                label="Veteran Mail Sent"
-              />
-            </Grid>
-            <Grid xs={12} md={6}>
-              <FormControlLabel
-                control={
-                  <Controller
-                    control={control}
-                    name="call.email_sent"
-                    render={({ field }) => (
-                      <Checkbox {...field} checked={field.value} disabled={disabled} />
-                    )}
-                  />
-                }
-                label="Email Veteran"
-              />
-            </Grid>
-          </Grid>
-        </CardContent>
-      </Card>
 
       {/* Emergency Contact Card */}
       <Card id="emergency-contact-section" elevation={2}>

--- a/src/components/main/veteran/essential-info-section.js
+++ b/src/components/main/veteran/essential-info-section.js
@@ -15,7 +15,7 @@ import OutlinedInput from '@mui/material/OutlinedInput';
 import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { Medal, Airplane, FirstAid } from '@phosphor-icons/react';
+import { Medal, Airplane, FirstAid, Headset } from '@phosphor-icons/react';
 import { Option } from '@/components/core/option';
 import { FormSectionHeader } from '@/components/main/shared/form-section-header';
 import { HistoryButton } from '@/components/main/shared/history-button';
@@ -336,6 +336,105 @@ export function EssentialInfoSection({ control, errors, veteran, onOpenHistory, 
         </CardContent>
       </Card>
 
+      {/* Call Center Information Card */}
+      <Card elevation={2}>
+        <CardContent>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 3 }}>
+            <FormSectionHeader 
+              icon={Headset} 
+              title="Call Center Information" 
+            />
+            <HistoryButton
+              title="Call Center"
+              history={veteran?.call?.history || []}
+              onOpenHistory={onOpenHistory}
+            />
+          </Stack>
+          <Grid container spacing={3}>
+            <Grid xs={12} md={6}>
+              <Controller
+                control={control}
+                name="call.assigned_to"
+                render={({ field }) => (
+                  <FormControl error={Boolean(errors.call?.assigned_to)} fullWidth disabled={disabled}>
+                    <InputLabel>Call Assigned To</InputLabel>
+                    <OutlinedInput {...field} inputProps={{ maxLength: 30 }} />
+                    {errors.call?.assigned_to ? <FormHelperText>{errors.call.assigned_to.message}</FormHelperText> : null}
+                  </FormControl>
+                )}
+              />
+            </Grid>
+            <Grid xs={12}>
+              <Controller
+                control={control}
+                name="call.notes"
+                render={({ field }) => (
+                  <FormControl error={Boolean(errors.call?.notes)} fullWidth disabled={disabled}>
+                    <InputLabel>Call Center Notes</InputLabel>
+                    <OutlinedInput {...field} multiline rows={3} />
+                    {errors.call?.notes ? <FormHelperText>{errors.call.notes.message}</FormHelperText> : null}
+                  </FormControl>
+                )}
+              />
+            </Grid>
+            <Grid xs={12} md={6}>
+              <Controller
+                control={control}
+                name="flight.confirmed_date"
+                render={({ field }) => (
+                  <FormControl error={Boolean(errors.flight?.confirmed_date)} fullWidth disabled={disabled}>
+                    <InputLabel>Confirmed Date</InputLabel>
+                    <OutlinedInput {...field} type="date" />
+                    {errors.flight?.confirmed_date ? <FormHelperText>{errors.flight.confirmed_date.message}</FormHelperText> : null}
+                  </FormControl>
+                )}
+              />
+            </Grid>
+            <Grid xs={12} md={6}>
+              <Controller
+                control={control}
+                name="flight.confirmed_by"
+                render={({ field }) => (
+                  <FormControl error={Boolean(errors.flight?.confirmed_by)} fullWidth disabled={disabled}>
+                    <InputLabel>Confirmed By</InputLabel>
+                    <OutlinedInput {...field} inputProps={{ maxLength: 30 }} />
+                    {errors.flight?.confirmed_by ? <FormHelperText>{errors.flight.confirmed_by.message}</FormHelperText> : null}
+                  </FormControl>
+                )}
+              />
+            </Grid>
+            <Grid xs={12} md={6}>
+              <FormControlLabel
+                control={
+                  <Controller
+                    control={control}
+                    name="call.mail_sent"
+                    render={({ field }) => (
+                      <Checkbox {...field} checked={field.value} disabled={disabled} />
+                    )}
+                  />
+                }
+                label="Veteran Mail Sent"
+              />
+            </Grid>
+            <Grid xs={12} md={6}>
+              <FormControlLabel
+                control={
+                  <Controller
+                    control={control}
+                    name="call.email_sent"
+                    render={({ field }) => (
+                      <Checkbox {...field} checked={field.value} disabled={disabled} />
+                    )}
+                  />
+                }
+                label="Email Veteran"
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
       {/* Flight Status Card */}
       <Card id="flight-section" elevation={2}>
         <CardContent>
@@ -443,32 +542,6 @@ export function EssentialInfoSection({ control, errors, veteran, onOpenHistory, 
                       <Option value="Bravo5">Bravo5</Option>
                     </Select>
                     {errors.flight?.bus ? <FormHelperText>{errors.flight.bus.message}</FormHelperText> : null}
-                  </FormControl>
-                )}
-              />
-            </Grid>
-            <Grid xs={12} md={6}>
-              <Controller
-                control={control}
-                name="flight.confirmed_date"
-                render={({ field }) => (
-                  <FormControl error={Boolean(errors.flight?.confirmed_date)} fullWidth disabled={disabled}>
-                    <InputLabel>Confirmed Date</InputLabel>
-                    <OutlinedInput {...field} type="date" />
-                    {errors.flight?.confirmed_date ? <FormHelperText>{errors.flight.confirmed_date.message}</FormHelperText> : null}
-                  </FormControl>
-                )}
-              />
-            </Grid>
-            <Grid xs={12} md={6}>
-              <Controller
-                control={control}
-                name="flight.confirmed_by"
-                render={({ field }) => (
-                  <FormControl error={Boolean(errors.flight?.confirmed_by)} fullWidth disabled={disabled}>
-                    <InputLabel>Confirmed By</InputLabel>
-                    <OutlinedInput {...field} inputProps={{ maxLength: 30 }} />
-                    {errors.flight?.confirmed_by ? <FormHelperText>{errors.flight.confirmed_by.message}</FormHelperText> : null}
                   </FormControl>
                 )}
               />


### PR DESCRIPTION
## Implementation

### 1. [veteran/essential-info-section.js](src/components/main/veteran/essential-info-section.js)

- **Add** the Call Center Information card between Medical Information and Flight Status (after the Medical card, before the Flight Status card). Reuse the same structure as in veteran contact-info-section: `FormSectionHeader` with Headset icon and title "Call Center Information", `HistoryButton` for `veteran?.call?.history`, and fields:
  - Call Assigned To (`call.assigned_to`)
  - Call Center Notes (`call.notes`)
  - **Confirmed Date** (`flight.confirmed_date`, type="date")
  - **Confirmed By** (`flight.confirmed_by`, maxLength 30)
  - Veteran Mail Sent (`call.mail_sent`), Email Veteran (`call.email_sent`) checkboxes
- **Remove** the Confirmed Date and Confirmed By controller blocks from the Flight Status card (the two `Grid` blocks for `flight.confirmed_date` and `flight.confirmed_by` around lines 451–472).
- **Add** import for `Headset` from `@phosphor-icons/react` (guardian uses it for Call Center).

Field names (`flight.confirmed_date`, `flight.confirmed_by`, `call.`*) stay unchanged so form submission and API are unaffected.

### 2. [veteran/contact-info-section.js](src/components/main/veteran/contact-info-section.js)

- **Remove** the entire "Call Center Information" card (the `<Card>` block from the comment `{/* Call Center Information Card */}` through its closing `</Card>`, including HistoryButton and all call/confirmation fields). Leave Address, Emergency Contact, Alternate Contact, Guardian, and Mail Call cards unchanged.

### 3. Tests

- **[veteran/tests/contact-info-section.test.js](src/components/main/veteran/__tests__/contact-info-section.test.js)**  
  - In "renders contact information section with all cards": remove the assertion `expect(screen.getByText('Call Center Information')).toBeInTheDocument()` so the test no longer expects Call Center in ContactInfoSection.  
  - Remove or refactor "renders call center information fields": those fields (e.g. `call.assigned_to`, `call.notes`) no longer render in ContactInfoSection. Easiest is to remove this test so ContactInfoSection tests only what that section still contains (address, emergency contact, guardian, etc.).
- **[veteran/tests/essential-info-section.test.js](src/components/main/veteran/__tests__/essential-info-section.test.js)**  
  - In "renders essential information section with all cards": add `expect(screen.getByText('Call Center Information')).toBeInTheDocument()` so the section is expected in Essential.  
  - Add a test that Call Center fields and Confirmed Date/By appear in EssentialInfoSection (e.g. query for "Call Center Information", and optionally for labels "Confirmed Date", "Confirmed By", and inputs for `call.assigned_to` / `call.notes`). This replaces the coverage lost from contact-info-section.
- **veteran-edit-form.test.js**: No change required. It does not assert section order or that "Call Center Information" is under Contact; it uses full form and API mocks. Running the full test suite will confirm nothing regresses.