### PR TITLE
Add how heard about dropdown to call center forms (#111)

### DIFF
--- a/src/components/main/guardian/__tests__/essential-info-section.test.js
+++ b/src/components/main/guardian/__tests__/essential-info-section.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import '@testing-library/jest-dom';
@@ -112,6 +112,49 @@ describe('EssentialInfoSection', () => {
 
     expect(container.querySelector('input[name="call.assigned_to"]')).toBeInTheDocument();
     expect(container.querySelector('input[name="call.notes"]') || container.querySelector('textarea[name="call.notes"]')).toBeInTheDocument();
+  });
+
+  test('renders how heard about SSHF dropdown in call center section', () => {
+    const mockFlightOptions = [
+      { value: 'FL123', label: 'Flight 123', disabled: false },
+    ];
+    const { container } = render(
+      <TestWrapper defaultValues={{ call: { assigned_to: '', notes: '', how_heard_about: 'Unknown' } }}>
+        <EssentialInfoSection
+          errors={{}}
+          guardian={mockGuardian}
+          onOpenHistory={mockOnOpenHistory}
+          flightOptions={mockFlightOptions}
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('How Heard About SSHF')).toBeInTheDocument();
+    expect(container.querySelector('[name="call.how_heard_about"]')).toBeInTheDocument();
+  });
+
+  test('allows selecting how heard about value', async () => {
+    const user = userEvent.setup();
+    const mockFlightOptions = [
+      { value: 'FL123', label: 'Flight 123', disabled: false },
+    ];
+    const { container } = render(
+      <TestWrapper defaultValues={{ call: { assigned_to: '', notes: '', how_heard_about: 'Unknown' } }}>
+        <EssentialInfoSection
+          errors={{}}
+          guardian={mockGuardian}
+          onOpenHistory={mockOnOpenHistory}
+          flightOptions={mockFlightOptions}
+        />
+      </TestWrapper>
+    );
+
+    const input = container.querySelector('[name="call.how_heard_about"]');
+    const selectDisplay = input.closest('.MuiFormControl-root').querySelector('.MuiSelect-select');
+    fireEvent.mouseDown(selectDisplay);
+    await user.click(screen.getByRole('option', { name: 'social media' }));
+
+    expect(selectDisplay).toHaveTextContent('social media');
   });
 
   test('displays error messages for medical fields', () => {

--- a/src/components/main/guardian/__tests__/guardian-edit-form.test.js
+++ b/src/components/main/guardian/__tests__/guardian-edit-form.test.js
@@ -246,6 +246,21 @@ describe('GuardianEditForm - Update Functionality', () => {
     });
   });
 
+  test('includes call.how_heard_about in API call with Unknown default', async () => {
+    const user = userEvent.setup();
+    render(<GuardianEditForm guardian={mockGuardian} />);
+
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      const payload = mockUpdateGuardian.mock.calls[0][1];
+      expect(payload.call).toEqual(
+        expect.objectContaining({ how_heard_about: 'Unknown' })
+      );
+    });
+  });
+
   test('excludes history arrays from API call', async () => {
     const user = userEvent.setup();
     render(<GuardianEditForm guardian={mockGuardian} />);

--- a/src/components/main/guardian/essential-info-section.js
+++ b/src/components/main/guardian/essential-info-section.js
@@ -20,6 +20,8 @@ import { Option } from '@/components/core/option';
 import { FormSectionHeader } from '@/components/main/shared/form-section-header';
 import { HistoryButton } from '@/components/main/shared/history-button';
 import { PersonalInformationCard } from '@/components/main/shared/personal-information-card';
+import { FormSelectField } from '@/components/main/shared/form-select-field';
+import { howHeardAboutOptions } from '@/schemas/call';
 
 export function EssentialInfoSection({ control, errors, guardian, onOpenHistory, flightOptions, disabled = false }) {
   return (
@@ -244,6 +246,15 @@ export function EssentialInfoSection({ control, errors, guardian, onOpenHistory,
                 )}
               />
             </Grid>
+            <FormSelectField
+              control={control}
+              name="call.how_heard_about"
+              label="How Heard About SSHF"
+              error={errors.call?.how_heard_about}
+              options={howHeardAboutOptions}
+              disabled={disabled}
+              gridProps={{ xs: 12, md: 6 }}
+            />
             <Grid xs={12}>
               <Controller
                 control={control}

--- a/src/components/main/guardian/guardian-edit-form.js
+++ b/src/components/main/guardian/guardian-edit-form.js
@@ -190,10 +190,13 @@ export function GuardianEditForm({ guardian, onNavigationReady, onNavigate }) {
       paid: false,
       exempt: false
     },
-    call: guardian.call || {
+    call: {
       assigned_to: '',
       notes: '',
-      email_sent: false
+      how_heard_about: 'Unknown',
+      email_sent: false,
+      ...(guardian.call || {}),
+      how_heard_about: guardian.call?.how_heard_about ?? 'Unknown',
     },
     emerg_contact: guardian.emerg_contact || { 
       name: '', 

--- a/src/components/main/veteran/__tests__/essential-info-section.test.js
+++ b/src/components/main/veteran/__tests__/essential-info-section.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm } from 'react-hook-form';
 import '@testing-library/jest-dom';
@@ -101,6 +101,49 @@ describe('EssentialInfoSection', () => {
     expect(screen.getByText('Confirmed By')).toBeInTheDocument();
     expect(container.querySelector('input[name="call.assigned_to"]')).toBeInTheDocument();
     expect(container.querySelector('input[name="call.notes"]') || container.querySelector('textarea[name="call.notes"]')).toBeInTheDocument();
+  });
+
+  test('renders how heard about SSHF dropdown in call center section', () => {
+    const mockFlightOptions = [
+      { value: 'FL123', label: 'Flight 123', disabled: false },
+    ];
+    const { container } = render(
+      <TestWrapper defaultValues={{ call: { assigned_to: '', notes: '', how_heard_about: 'Unknown' } }}>
+        <EssentialInfoSection
+          errors={{}}
+          veteran={mockVeteran}
+          onOpenHistory={mockOnOpenHistory}
+          flightOptions={mockFlightOptions}
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('How Heard About SSHF')).toBeInTheDocument();
+    expect(container.querySelector('[name="call.how_heard_about"]')).toBeInTheDocument();
+  });
+
+  test('allows selecting how heard about value', async () => {
+    const user = userEvent.setup();
+    const mockFlightOptions = [
+      { value: 'FL123', label: 'Flight 123', disabled: false },
+    ];
+    const { container } = render(
+      <TestWrapper defaultValues={{ call: { assigned_to: '', notes: '', how_heard_about: 'Unknown' } }}>
+        <EssentialInfoSection
+          errors={{}}
+          veteran={mockVeteran}
+          onOpenHistory={mockOnOpenHistory}
+          flightOptions={mockFlightOptions}
+        />
+      </TestWrapper>
+    );
+
+    const input = container.querySelector('[name="call.how_heard_about"]');
+    const selectDisplay = input.closest('.MuiFormControl-root').querySelector('.MuiSelect-select');
+    fireEvent.mouseDown(selectDisplay);
+    await user.click(screen.getByRole('option', { name: 'social media' }));
+
+    expect(selectDisplay).toHaveTextContent('social media');
   });
 
   test('renders service information fields', () => {

--- a/src/components/main/veteran/__tests__/veteran-edit-form.test.js
+++ b/src/components/main/veteran/__tests__/veteran-edit-form.test.js
@@ -277,6 +277,21 @@ describe('VeteranEditForm - Update Functionality', () => {
     });
   });
 
+  test('includes call.how_heard_about in API call with Unknown default', async () => {
+    const user = userEvent.setup();
+    render(<VeteranEditForm veteran={mockVeteran} />);
+
+    const saveButton = screen.getByRole('button', { name: /save changes/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      const payload = mockUpdateVeteran.mock.calls[0][1];
+      expect(payload.call).toEqual(
+        expect.objectContaining({ how_heard_about: 'Unknown' })
+      );
+    });
+  });
+
   test('excludes history arrays from API call', async () => {
     const user = userEvent.setup();
     render(<VeteranEditForm veteran={mockVeteran} />);

--- a/src/components/main/veteran/essential-info-section.js
+++ b/src/components/main/veteran/essential-info-section.js
@@ -20,6 +20,8 @@ import { Option } from '@/components/core/option';
 import { FormSectionHeader } from '@/components/main/shared/form-section-header';
 import { HistoryButton } from '@/components/main/shared/history-button';
 import { PersonalInformationCard } from '@/components/main/shared/personal-information-card';
+import { FormSelectField } from '@/components/main/shared/form-select-field';
+import { howHeardAboutOptions } from '@/schemas/call';
 
 export function EssentialInfoSection({ control, errors, veteran, onOpenHistory, flightOptions, disabled = false }) {
   return (
@@ -364,6 +366,15 @@ export function EssentialInfoSection({ control, errors, veteran, onOpenHistory, 
                 )}
               />
             </Grid>
+            <FormSelectField
+              control={control}
+              name="call.how_heard_about"
+              label="How Heard About SSHF"
+              error={errors.call?.how_heard_about}
+              options={howHeardAboutOptions}
+              disabled={disabled}
+              gridProps={{ xs: 12, md: 6 }}
+            />
             <Grid xs={12}>
               <Controller
                 control={control}

--- a/src/components/main/veteran/veteran-edit-form.js
+++ b/src/components/main/veteran/veteran-edit-form.js
@@ -236,11 +236,14 @@ export function VeteranEditForm({ veteran, onNavigationReady, onNavigate }) {
       adopt: false,
       address: { phone: '', email: '' }
     },
-    call: veteran.call || {
+    call: {
       assigned_to: '',
       notes: '',
+      how_heard_about: 'Unknown',
       mail_sent: false,
-      email_sent: false
+      email_sent: false,
+      ...(veteran.call || {}),
+      how_heard_about: veteran.call?.how_heard_about ?? 'Unknown',
     },
     shirt: veteran.shirt || { size: '' },
     apparel: veteran.apparel || { 

--- a/src/schemas/__tests__/call.test.js
+++ b/src/schemas/__tests__/call.test.js
@@ -1,0 +1,22 @@
+import { HOW_HEARD_ABOUT_VALUES, howHeardAboutSchema } from '@/schemas/call';
+import openapi from '../../../docs/openapi.json';
+
+describe('call schema', () => {
+  test('HOW_HEARD_ABOUT_VALUES matches OpenAPI Veteran call.how_heard_about enum', () => {
+    const openapiEnum = openapi.components.schemas.Veteran.properties.call.properties.how_heard_about.enum;
+    expect(HOW_HEARD_ABOUT_VALUES).toEqual(openapiEnum);
+  });
+
+  test('HOW_HEARD_ABOUT_VALUES matches OpenAPI Guardian call.how_heard_about enum', () => {
+    const openapiEnum = openapi.components.schemas.Guardian.properties.call.properties.how_heard_about.enum;
+    expect(HOW_HEARD_ABOUT_VALUES).toEqual(openapiEnum);
+  });
+
+  test('howHeardAboutSchema defaults to Unknown', () => {
+    expect(howHeardAboutSchema.parse(undefined)).toBe('Unknown');
+  });
+
+  test('howHeardAboutSchema rejects invalid values', () => {
+    expect(() => howHeardAboutSchema.parse('invalid')).toThrow();
+  });
+});

--- a/src/schemas/call.js
+++ b/src/schemas/call.js
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const HOW_HEARD_ABOUT_VALUES = [
+  'Unknown',
+  'VA or vet org',
+  'radio segment',
+  'tv interview or segment',
+  'school or community event',
+  'an SSHF event or fundraiser',
+  'newspaper or magazine ad or story',
+  'social media',
+  'family or friend',
+  'airport signage or experience',
+  'Kwik Trip Pump ad',
+  'other',
+];
+
+export const howHeardAboutSchema = z.enum(HOW_HEARD_ABOUT_VALUES).default('Unknown');
+
+export const howHeardAboutOptions = HOW_HEARD_ABOUT_VALUES.map((value) => ({
+  value,
+  label: value,
+}));

--- a/src/schemas/guardian.js
+++ b/src/schemas/guardian.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { howHeardAboutSchema } from '@/schemas/call';
 
 export const guardianSchema = z.object({
   _id: z.string().optional(), // CouchDB ID
@@ -99,6 +100,7 @@ export const guardianSchema = z.object({
     notes: z.string().optional(),
     email_sent: z.boolean().default(false),
     assigned_to: z.string().optional(),
+    how_heard_about: howHeardAboutSchema,
     mail_sent: z.boolean().default(false),
     history: z.array(
       z.object({


### PR DESCRIPTION
## Summary

- Add a **How Heard About SSHF** dropdown (`call.how_heard_about`) to the Call Center Information section on Veteran and Guardian edit forms.
- Introduce shared enum/options in `src/schemas/call.js`, aligned with the OpenAPI contract from sshf-api PR #64.
- Default legacy/missing values to `Unknown` and persist through existing update flows.

Closes #111

## Test plan

- [x] `npx jest src/schemas/__tests__/call.test.js`
- [x] `npx jest src/components/main/veteran/__tests__/essential-info-section.test.js`
- [x] `npx jest src/components/main/guardian/__tests__/essential-info-section.test.js`
- [x] `npx jest src/components/main/veteran/__tests__/veteran-edit-form.test.js`
- [x] `npx jest src/components/main/guardian/__tests__/guardian-edit-form.test.js`
- [x] Manual save against live API (veteran + guardian)