### PR TITLE
Add telephone number as a search option

### DIFF
--- a/src/app/(main)/search/page.js
+++ b/src/app/(main)/search/page.js
@@ -52,12 +52,28 @@ export default function Page() {
         <Option key="Future-PostRestriction" value="Future-PostRestriction">Future-PostRestriction</Option>,
         <Option key="Copied" value="Copied">Copied</Option>
       ]
-    }
+    },
+    {
+      property: 'phoneNum',
+      propertyFriendlyName: 'Phone',
+      filterType: 'phone',
+      placeholder: 'Phone number...',
+    },
   ]);
   
   const handleQuickSearch = (event) => {
     const value = event.target.value;
     setQuickSearch(value);
+
+    // Clear phone filter immediately when user starts last-name search
+    if (value && isInitialized) {
+      const params = new URLSearchParams(window.location.search);
+      if (params.has('phoneNum')) {
+        params.delete('phoneNum');
+        const newUrl = params.toString() ? `?${params.toString()}` : '/search';
+        router.replace(newUrl, { scroll: false });
+      }
+    }
   };
   
   // Debounce the search input - wait 250ms after user stops typing
@@ -77,6 +93,7 @@ export default function Page() {
     const params = new URLSearchParams(window.location.search);
     if (debouncedSearch) {
       params.set('lastName', debouncedSearch);
+      params.delete('phoneNum');
     } else {
       params.delete('lastName');
     }
@@ -86,6 +103,27 @@ export default function Page() {
     const newUrl = params.toString() ? `?${params.toString()}` : '/search';
     router.replace(newUrl, { scroll: false });
   }, [debouncedSearch, isInitialized, router]);
+
+  // When phone search is applied via URL, clear last-name quick search
+  const phoneNumParam = searchParams.get('phoneNum') || '';
+
+  React.useEffect(() => {
+    if (!isInitialized) return;
+
+    const digitCount = phoneNumParam.replace(/\D/g, '').length;
+    if (digitCount < 3) return;
+
+    setQuickSearch('');
+    setDebouncedSearch('');
+
+    const params = new URLSearchParams(window.location.search);
+    if (!params.get('lastName')) return;
+
+    params.delete('lastName');
+    const newUrl = params.toString() ? `?${params.toString()}` : '/search';
+    router.replace(newUrl, { scroll: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- router identity is unstable; only react to phoneNum changes
+  }, [phoneNumParam, isInitialized]);
 
   const updatesearchFilters = (newsearchFilter) => {
     setSearchFilters(newsearchFilter);
@@ -178,16 +216,23 @@ export default function Page() {
         })
       ];
 
-      setSearchFilters(prev => [
-        prev[0], // Keep lastName filter (hidden)
-        prev[1], // Keep status filter
-        { 
-          property: "flight", 
-          propertyFriendlyName: "Flight", 
-          filterType: "combo", 
-          options: flightOptions
-        }
-      ]);
+      setSearchFilters(prev => {
+        const lastNameFilter = prev.find(f => f.property === 'lastName');
+        const statusFilter = prev.find(f => f.property === 'status');
+        const phoneFilter = prev.find(f => f.property === 'phoneNum');
+
+        return [
+          lastNameFilter,
+          statusFilter,
+          {
+            property: "flight",
+            propertyFriendlyName: "Flight",
+            filterType: "combo",
+            options: flightOptions,
+          },
+          phoneFilter,
+        ].filter(Boolean);
+      });
     }
   }, [flights]);
 

--- a/src/components/core/table/__tests__/text-filter.test.js
+++ b/src/components/core/table/__tests__/text-filter.test.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { TextFilterButton } from '@/components/core/table/text-filter';
+
+describe('TextFilterButton', () => {
+  test('phone mode shows helper text and does not apply while typing', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    render(
+      <TextFilterButton
+        label="Phone"
+        value=""
+        handleChange={handleChange}
+        applyMode="explicit"
+        helperText="Enter at least 3 digits"
+        placeholder="Phone number..."
+        validate={(val) => ({
+          valid: (val || '').replace(/\D/g, '').length >= 3,
+          message: 'Enter at least 3 digits',
+        })}
+      />
+    );
+
+    await user.click(screen.getByText('Phone'));
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '41');
+
+    await waitFor(() => {
+      expect(handleChange).not.toHaveBeenCalled();
+    }, { timeout: 800 });
+
+    expect(screen.getByText('Enter at least 3 digits')).toBeInTheDocument();
+  });
+
+  test('phone mode applies on Apply when valid', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    render(
+      <TextFilterButton
+        label="Phone"
+        value=""
+        handleChange={handleChange}
+        applyMode="explicit"
+        helperText="Enter at least 3 digits"
+        placeholder="Phone number..."
+        validate={(val) => ({
+          valid: (val || '').replace(/\D/g, '').length >= 3,
+          message: 'Enter at least 3 digits',
+        })}
+      />
+    );
+
+    await user.click(screen.getByText('Phone'));
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '414-817');
+
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(handleChange).toHaveBeenCalledWith('414-817');
+  });
+
+  test('phone mode does not apply when fewer than 3 digits on Apply click', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    render(
+      <TextFilterButton
+        label="Phone"
+        value=""
+        handleChange={handleChange}
+        applyMode="explicit"
+        helperText="Enter at least 3 digits"
+        validate={(val) => ({
+          valid: (val || '').replace(/\D/g, '').length >= 3,
+          message: 'Enter at least 3 digits',
+        })}
+      />
+    );
+
+    await user.click(screen.getByText('Phone'));
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '41');
+
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Enter at least 3 digits')).toBeInTheDocument();
+  });
+
+  test('default text mode still debounces apply while typing', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    render(
+      <TextFilterButton
+        label="Name"
+        value=""
+        handleChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByText('Name'));
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'Smi');
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalled();
+    }, { timeout: 1000 });
+  });
+});

--- a/src/components/core/table/api-table.js
+++ b/src/components/core/table/api-table.js
@@ -29,8 +29,22 @@ import { TextFilterButton } from '@/components/core/table/text-filter';
 import { ComboFilterButton } from '@/components/core/table/combo-filter';
 import { paths } from '@/paths';
 import { formatFlightNameForDisplay, ensureFlightPrefix } from '@/lib/flights';
+import { isValidPhoneSearchTerm } from '@/lib/phone-search';
 
 import { api } from '@/lib/api';
+
+const phoneFilterValidate = (value) => ({
+  valid: isValidPhoneSearchTerm(value),
+  message: 'Enter at least 3 digits',
+});
+
+const isActiveFilterValue = (filter) => {
+  if (filter.property === 'phoneNum') {
+    return isValidPhoneSearchTerm(filter.value);
+  }
+
+  return filter.value != undefined && filter.value !== '';
+};
 
 
 let LoadingOrEmptyMessage = ({ rows, entityFriendlyName, columns, tablePageData, isLoading }) => {
@@ -114,7 +128,13 @@ let TableTabs = ({ tableTabs, handleTabChange, currentTab }) => {
 
 let FiltersAndSorts = ({ filters, sorts, handleChange, handleClearFilters }) => {
     // Check if any filter has a value, including hidden ones (like lastName from quick search)
-    const hasFilters = filters.some(f => f.value != undefined && f.value !== '');
+    const hasFilters = filters.some((f) => {
+      if (f.hidden) {
+        return f.value != undefined && f.value !== '';
+      }
+
+      return isActiveFilterValue(f);
+    });
     let filterButtons = [];
     let sortButtons = [];
     
@@ -143,6 +163,20 @@ let FiltersAndSorts = ({ filters, sorts, handleChange, handleClearFilters }) => 
                         handleChange={ (value) => {
                             handleChange(f.property, value);
                         }} />
+                    break;
+                case "phone":
+                    filterButton = <TextFilterButton
+                        key={f.property}
+                        value={f.value || f.defaultValue || ''}
+                        label={f.propertyFriendlyName}
+                        applyMode="explicit"
+                        helperText="Enter at least 3 digits"
+                        placeholder={f.placeholder || 'Phone number...'}
+                        validate={phoneFilterValidate}
+                        handleChange={(value) => {
+                            handleChange(f.property, value);
+                        }}
+                    />
                     break;
             }
 
@@ -276,6 +310,10 @@ export function ApiTable({
                 if (urlValue) {
                     if (f.property === 'lastName') {
                         filterParams.lastname = urlValue;
+                    } else if (f.property === 'phoneNum') {
+                        if (isValidPhoneSearchTerm(urlValue)) {
+                            filterParams.phone_num = urlValue;
+                        }
                     } else if (f.property === 'status') {
                         filterParams.status = urlValue;
                     } else if (f.property === 'flight') {
@@ -287,8 +325,17 @@ export function ApiTable({
             
             // Also check for lastName directly from URL (for quick search, even if not in filters array)
             const lastNameFromUrl = searchParams.get('lastName');
-            if (lastNameFromUrl && !filterParams.lastname) {
+            if (lastNameFromUrl && !filterParams.lastname && !filterParams.phone_num) {
                 filterParams.lastname = lastNameFromUrl;
+            }
+
+            const phoneNumFromUrl = searchParams.get('phoneNum');
+            if (phoneNumFromUrl && !filterParams.phone_num && isValidPhoneSearchTerm(phoneNumFromUrl)) {
+                filterParams.phone_num = phoneNumFromUrl;
+            }
+
+            if (filterParams.phone_num) {
+                delete filterParams.lastname;
             }
             
             // Also check for flight directly from URL (flight filter is added dynamically, may not be in filters array on refresh)
@@ -376,7 +423,7 @@ export function ApiTable({
         const searchParamsBuilder = new URLSearchParams();
         
         // Known filter properties that should be managed
-        const knownFilterProperties = new Set(['lastName', 'status', 'flight']);
+        const knownFilterProperties = new Set(['lastName', 'status', 'flight', 'phoneNum']);
 
         // Start with all current params
         currentParams.forEach((value, key) => {

--- a/src/components/core/table/text-filter.js
+++ b/src/components/core/table/text-filter.js
@@ -17,7 +17,15 @@ const debounce = (fn, delay) => {
   };
 };
 
-export function TextFilterButton ({ value, label, handleChange }) {
+export function TextFilterButton ({
+  value,
+  label,
+  handleChange,
+  applyMode = 'debounced',
+  helperText = '*Filter is Case Insensitive',
+  placeholder = '',
+  validate,
+}) {
 
     return (
         <FilterButton
@@ -30,15 +38,30 @@ export function TextFilterButton ({ value, label, handleChange }) {
             onFilterDelete={() => {
               handleChange();
             }}
-            popover={<TextFilterPopover label={label} />}
+            popover={
+              <TextFilterPopover
+                label={label}
+                applyMode={applyMode}
+                helperText={helperText}
+                placeholder={placeholder}
+                validate={validate}
+              />
+            }
             value={value || undefined}
         />
     );
 }
 
-function TextFilterPopover ({ label = '' }) {
+function TextFilterPopover ({
+  label = '',
+  applyMode = 'debounced',
+  helperText = '*Filter is Case Insensitive',
+  placeholder = '',
+  validate,
+}) {
     const { anchorEl, onApply, onClose, open, value: initialValue } = useFilterContext();
     const [value, setValue] = React.useState('');
+    const [validationMessage, setValidationMessage] = React.useState('');
     
     // Create a debounced version of onApply that doesn't close the popover
     const debouncedApply = React.useCallback(
@@ -48,16 +71,45 @@ function TextFilterPopover ({ label = '' }) {
       }, 500),
       [onApply]
     );
+
+    const runValidation = React.useCallback((nextValue) => {
+      if (!validate) {
+        setValidationMessage('');
+        return { valid: true };
+      }
+
+      const result = validate(nextValue);
+      setValidationMessage(result.valid ? '' : result.message);
+      return result;
+    }, [validate]);
   
     React.useEffect(() => {
       setValue(initialValue ?? '');
+      setValidationMessage('');
     }, [initialValue]);
   
     // Handle input change
     const handleInputChange = (event) => {
       const newValue = event.target.value;
       setValue(newValue);
-      debouncedApply(newValue);
+
+      if (applyMode === 'debounced') {
+        debouncedApply(newValue);
+        return;
+      }
+
+      runValidation(newValue);
+    };
+
+    const handleApply = () => {
+      if (validate) {
+        const result = runValidation(value);
+        if (!result.valid) {
+          return;
+        }
+      }
+
+      onApply(value);
     };
   
     return (
@@ -67,17 +119,18 @@ function TextFilterPopover ({ label = '' }) {
             onChange={handleInputChange}
             onKeyUp={(event) => {
               if (event.key === 'Enter') {
-                onApply(value);
+                handleApply();
               }
             }}
+            placeholder={placeholder}
             value={value}
           />
-          <Typography variant="caption">*Filter is Case Insensitive</Typography>
+          <Typography variant="caption" color={validationMessage ? 'error' : 'textSecondary'}>
+            {validationMessage || helperText}
+          </Typography>
         </FormControl>
         <Button
-          onClick={() => {
-            onApply(value);
-          }}
+          onClick={handleApply}
           variant="contained"
         >
           Apply

--- a/src/components/main/search/__tests__/search-page.test.js
+++ b/src/components/main/search/__tests__/search-page.test.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+const mockReplace = jest.fn();
+const mockSearchParamsGet = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({
+    get: mockSearchParamsGet,
+  }),
+}));
+
+jest.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    hasRole: jest.fn(() => true),
+    isInGroup: jest.fn(() => true),
+  }),
+}));
+
+import { getFlights, formatFlightNameForDisplay, ensureFlightPrefix } from '@/lib/flights';
+
+const mockGetFlights = jest.fn(() => []);
+
+jest.mock('@/lib/flights', () => ({
+  getFlights: (...args) => mockGetFlights(...args),
+  formatFlightNameForDisplay: jest.fn((name) => name),
+  ensureFlightPrefix: jest.fn((name) => name),
+}));
+
+jest.mock('@/config', () => ({
+  config: { site: { name: 'SSHF' } },
+}));
+
+jest.mock('@/components/core/table/api-table', () => ({
+  ApiTable: ({ filters }) => (
+    <div data-testid="api-table">
+      {filters
+        .filter((f) => !f.hidden)
+        .map((f) => (
+          <span key={f.property}>{f.propertyFriendlyName}</span>
+        ))}
+    </div>
+  ),
+}));
+
+import Page from '@/app/(main)/search/page';
+
+describe('Search page', () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockSearchParamsGet.mockImplementation(() => null);
+    mockGetFlights.mockReturnValue([]);
+  });
+
+  test('renders Phone filter in filter bar alongside Status', async () => {
+    render(<Page />);
+
+    expect(await screen.findByText('Phone')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  test('renders Phone filter after Flight when flights are loaded', async () => {
+    mockGetFlights.mockReturnValue([{ _id: 'f1', name: 'SSHF-Test02' }]);
+
+    render(<Page />);
+
+    await screen.findByText('Flight');
+
+    const filterLabels = screen.getByTestId('api-table').querySelectorAll('span');
+    const labels = [...filterLabels].map((node) => node.textContent);
+    expect(labels).toEqual(['Status', 'Flight', 'Phone']);
+  });
+
+  test('typing in last name clears phoneNum from URL', async () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === 'phoneNum') return '414817';
+      return null;
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const lastNameInput = screen.getByPlaceholderText('Quick search by last name...');
+    await user.type(lastNameInput, 'S');
+
+    await waitFor(() => {
+      const replaceCalls = mockReplace.mock.calls.map((call) => call[0]);
+      expect(replaceCalls.some((url) => !url.includes('phoneNum='))).toBe(true);
+    }, { timeout: 1000 });
+  });
+
+  test('allows continued typing in last name after phone filter was active', async () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === 'phoneNum') return '414817';
+      return null;
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const lastNameInput = screen.getByPlaceholderText('Quick search by last name...');
+    await user.type(lastNameInput, 'Smi');
+
+    expect(lastNameInput).toHaveValue('Smi');
+  });
+});

--- a/src/components/main/search/search-card-view.js
+++ b/src/components/main/search/search-card-view.js
@@ -129,6 +129,11 @@ export function SearchCardView({ rows }) {
                     >
                       {row.name} {row.lastname}
                     </Typography>
+                    {row.phone ? (
+                      <Typography variant="body2" color="text.secondary">
+                        {row.phone}
+                      </Typography>
+                    ) : null}
                   </Box>
                 </Stack>
 

--- a/src/components/main/search/search-columns.js
+++ b/src/components/main/search/search-columns.js
@@ -100,6 +100,14 @@ export const searchColumns = [
             );
         }
     },
+    {
+        field: 'phone',
+        name: 'Phone',
+        width: '140px',
+        formatter: (row) => (
+            <Typography variant="body2">{row.phone || '—'}</Typography>
+        ),
+    },
     { 
         field: 'flight',
         name: 'Flight',

--- a/src/lib/__tests__/api-search.test.js
+++ b/src/lib/__tests__/api-search.test.js
@@ -1,0 +1,61 @@
+import { api } from '@/lib/api';
+import { toast } from '@/components/core/toaster';
+
+jest.mock('@/components/core/toaster', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/auth/domain/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('test-token'),
+    getRefreshToken: jest.fn(),
+    refreshToken: jest.fn(),
+    clearTokens: jest.fn(),
+  },
+}));
+
+describe('api.search', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [], total_rows: 0 }),
+    });
+    global.fetch = fetchMock;
+    toast.error.mockClear();
+  });
+
+  test('includes phone_num when valid and omits lastname', async () => {
+    await api.search({ lastname: 'Smith', phone_num: '414-817', status: 'Active' });
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('phone_num=414-817');
+    expect(url).not.toContain('lastname=');
+  });
+
+  test('includes lastname when phone_num is not valid', async () => {
+    await api.search({ lastname: 'Smith', phone_num: '41', status: 'Active' });
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('lastname=Smith');
+    expect(url).not.toContain('phone_num=');
+  });
+
+  test('includes lastname when phone_num is empty', async () => {
+    await api.search({ lastname: 'Smith', status: 'Active' });
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('lastname=Smith');
+    expect(url).not.toContain('phone_num=');
+  });
+
+  test('does not include phone_num when fewer than 3 digits', async () => {
+    await api.search({ phone_num: '12', status: 'Active' });
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).not.toContain('phone_num=');
+  });
+});

--- a/src/lib/__tests__/phone-search.test.js
+++ b/src/lib/__tests__/phone-search.test.js
@@ -1,0 +1,32 @@
+import { countPhoneDigits, isValidPhoneSearchTerm } from '@/lib/phone-search';
+
+describe('phone-search', () => {
+  describe('countPhoneDigits', () => {
+    test('counts digits only, ignoring formatting characters', () => {
+      expect(countPhoneDigits('(414) 817-1255')).toBe(10);
+      expect(countPhoneDigits('414-817')).toBe(6);
+      expect(countPhoneDigits('abc')).toBe(0);
+    });
+
+    test('handles empty and nullish values', () => {
+      expect(countPhoneDigits('')).toBe(0);
+      expect(countPhoneDigits(null)).toBe(0);
+      expect(countPhoneDigits(undefined)).toBe(0);
+    });
+  });
+
+  describe('isValidPhoneSearchTerm', () => {
+    test('returns true when at least 3 digits are present', () => {
+      expect(isValidPhoneSearchTerm('414')).toBe(true);
+      expect(isValidPhoneSearchTerm('(414) 8')).toBe(true);
+      expect(isValidPhoneSearchTerm('414-817-1255')).toBe(true);
+    });
+
+    test('returns false when fewer than 3 digits', () => {
+      expect(isValidPhoneSearchTerm('')).toBe(false);
+      expect(isValidPhoneSearchTerm('41')).toBe(false);
+      expect(isValidPhoneSearchTerm('(4)')).toBe(false);
+      expect(isValidPhoneSearchTerm('abc')).toBe(false);
+    });
+  });
+});

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,7 @@
 // API client for interacting with the backend API
 import { toast } from '@/components/core/toaster';
 import { tokenManager } from '@/lib/auth/domain/tokenManager';
+import { isValidPhoneSearchTerm } from '@/lib/phone-search';
 import { paths } from '@/paths';
 
 class ApiClient {
@@ -108,12 +109,17 @@ class ApiClient {
   }
 
   // Search for veterans and guardians
-  async search({ limit = 25, lastname = '', status = 'Active', flight = 'All' }) {
+  async search({ limit = 25, lastname = '', phone_num = '', status = 'Active', flight = 'All' }) {
     try {
       const queryParams = new URLSearchParams();
-      
+      const usePhoneSearch = isValidPhoneSearchTerm(phone_num);
+
       if (limit) queryParams.append('limit', limit);
-      if (lastname) queryParams.append('lastname', lastname);
+      if (usePhoneSearch) {
+        queryParams.append('phone_num', phone_num);
+      } else if (lastname) {
+        queryParams.append('lastname', lastname);
+      }
       if (status) queryParams.append('status', status);
       if (flight && flight !== 'All') queryParams.append('flight', flight);
 

--- a/src/lib/phone-search.js
+++ b/src/lib/phone-search.js
@@ -1,0 +1,7 @@
+export function countPhoneDigits(value) {
+  return (value || '').replace(/\D/g, '').length;
+}
+
+export function isValidPhoneSearchTerm(value) {
+  return countPhoneDigits(value) >= 3;
+}


### PR DESCRIPTION
## Summary
- Adds a Phone filter button on the Veterans & Guardians search page (after Status and Flight) that searches via the API `phone_num` parameter with explicit Apply and a minimum of 3 digits.
- Last-name quick search and phone search are mutually exclusive: applying phone clears last name, and typing in last name immediately clears phone while preserving status/flight filters.
- Search results show the returned `phone` field in the table and mobile card view.

## Test plan
- [x] `npm test` (96 tests passing)
- [x] Open Search Veterans & Guardians, apply a phone filter (e.g. `414`), confirm results load and last-name box clears
- [x] With phone active, type in last-name search and confirm phone filter collapses while status/flight remain
- [x] Clear phone via funnel-X and via Clear filters
- [x] Confirm shareable URL with `?phoneNum=...` restores phone search on refresh

Closes #108