### PR TITLE
Add extra data to the waitlist

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=330507742215-scerc6p0lvou59tufmohq1b7b4bj0l90.apps.googleusercontent.com
-NEXT_PUBLIC_ROLE_FULL_ACCESS=sshf_app_dev_full_access@starsandstripeshonorflight.org
-NEXT_PUBLIC_API_URL=https://sshf-api-330507742215.us-central1.run.app

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ out/
 junit.xml
 
 .env
+.env.local
 .DS_Store
 *.swp
 *~

--- a/src/components/main/waitlist/__tests__/waitlist-item.test.js
+++ b/src/components/main/waitlist/__tests__/waitlist-item.test.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { WaitlistItem } from '@/components/main/waitlist/waitlist-item';
+
+const renderRow = (ui) => render(<table><tbody>{ui}</tbody></table>);
+
+const veteranEntry = {
+  id: 'vet-1',
+  name: 'James Weimer',
+  age: 90,
+  city: 'Schiller Park',
+  appdate: '2024-07-25',
+  birth_date: '1935-04-01',
+  prefs: 'Guardian fee waiver.mm',
+  status: 'Future-Fall',
+  vet_type: 'Korea',
+  group: '855-1',
+  pairings: [{ id: 'grd-9', name: 'James Weimer Jr' }],
+};
+
+const guardianEntry = {
+  id: 'grd-1',
+  name: 'Rachel Stubner',
+  age: 56,
+  city: 'Menasha',
+  appdate: '2023-06-12',
+  birth_date: '1970-02-15',
+  prefs: 'Good for GRB',
+  status: 'Active',
+  vet_type: '',
+  group: '',
+  pairings: [
+    { id: 'vet-2', name: 'Gary Stubner' },
+    { id: 'vet-3', name: 'Vernin Tretow' },
+  ],
+};
+
+describe('WaitlistItem', () => {
+  test('renders veteran row with position, conflict chip, flight group and guardian link', () => {
+    renderRow(<WaitlistItem entry={veteranEntry} type="veterans" position={3} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'James Weimer' })).toHaveAttribute(
+      'href',
+      '/veterans/details?id=vet-1'
+    );
+    expect(screen.getByText('Korea')).toBeInTheDocument();
+    expect(screen.getByText('855-1')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'James Weimer Jr' })).toHaveAttribute(
+      'href',
+      '/guardians/details?id=grd-9'
+    );
+    expect(screen.getByText('Guardian fee waiver.mm')).toBeInTheDocument();
+  });
+
+  test('shows status chip with color when status is not Active', () => {
+    renderRow(<WaitlistItem entry={veteranEntry} type="veterans" position={1} />);
+
+    const chip = screen.getByText('Future-Fall');
+    expect(chip).toBeInTheDocument();
+    expect(chip.closest('.MuiChip-root')).toHaveClass('MuiChip-colorWarning');
+  });
+
+  test.each([
+    ['Future-Spring', 'MuiChip-colorSuccess'],
+    ['Future-Fall', 'MuiChip-colorWarning'],
+    ['Future-PostRestriction', 'MuiChip-colorError'],
+  ])('maps status %s to %s', (status, expectedClass) => {
+    renderRow(
+      <WaitlistItem entry={{ ...veteranEntry, status }} type="veterans" position={1} />
+    );
+
+    expect(screen.getByText(status).closest('.MuiChip-root')).toHaveClass(expectedClass);
+  });
+
+  test('does not render a status chip when status is Active', () => {
+    renderRow(
+      <WaitlistItem entry={{ ...veteranEntry, status: 'Active' }} type="veterans" position={1} />
+    );
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+
+  test('renders guardian row with veteran pairing links and no conflict or group cells', () => {
+    renderRow(<WaitlistItem entry={guardianEntry} type="guardians" position={7} />);
+
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Gary Stubner' })).toHaveAttribute(
+      'href',
+      '/veterans/details?id=vet-2'
+    );
+    expect(screen.getByRole('link', { name: 'Vernin Tretow' })).toHaveAttribute(
+      'href',
+      '/veterans/details?id=vet-3'
+    );
+    expect(screen.queryByText('Korea')).not.toBeInTheDocument();
+    // Guardian rows: position, name, age, birth date, city, app date, veterans, notes = 8 cells
+    expect(screen.getAllByRole('cell')).toHaveLength(8);
+  });
+
+  test('veteran rows have 10 cells', () => {
+    renderRow(<WaitlistItem entry={veteranEntry} type="veterans" position={1} />);
+
+    expect(screen.getAllByRole('cell')).toHaveLength(10);
+  });
+
+  test('shows em-dash for missing pairing, conflict and group', () => {
+    renderRow(
+      <WaitlistItem
+        entry={{ ...veteranEntry, pairings: [], vet_type: '', group: '', prefs: '' }}
+        type="veterans"
+        position={1}
+      />
+    );
+
+    // conflict, group, pairing and notes cells all fall back to em-dash
+    expect(screen.getAllByText('—')).toHaveLength(4);
+  });
+});

--- a/src/components/main/waitlist/__tests__/waitlist-mobile-card.test.js
+++ b/src/components/main/waitlist/__tests__/waitlist-mobile-card.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { WaitlistMobileCard } from '@/components/main/waitlist/waitlist-mobile-card';
+
+const veteranEntry = {
+  id: 'vet-1',
+  name: 'James Weimer',
+  age: 90,
+  city: 'Schiller Park',
+  appdate: '2024-07-25',
+  birth_date: '1935-04-01',
+  prefs: 'Guardian fee waiver',
+  status: 'Future-Fall',
+  vet_type: 'Korea',
+  group: '855-1',
+  pairings: [{ id: 'grd-9', name: 'James Weimer Jr' }],
+};
+
+const guardianEntry = {
+  id: 'grd-1',
+  name: 'Rachel Stubner',
+  age: 56,
+  city: 'Menasha',
+  appdate: '2023-06-12',
+  birth_date: '1970-02-15',
+  prefs: 'Good for GRB',
+  status: 'Active',
+  vet_type: '',
+  group: '',
+  pairings: [{ id: 'vet-2', name: 'Gary Stubner' }],
+};
+
+describe('WaitlistMobileCard', () => {
+  test('renders veteran card with position, status chip, conflict, group and guardian link', () => {
+    render(<WaitlistMobileCard entry={veteranEntry} type="veterans" position={3} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Future-Fall')).toBeInTheDocument();
+    expect(screen.getByText('Korea')).toBeInTheDocument();
+    expect(screen.getByText('855-1')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'James Weimer Jr' })).toHaveAttribute(
+      'href',
+      '/guardians/details?id=grd-9'
+    );
+  });
+
+  test('renders guardian card with veteran pairing and no conflict or group labels', () => {
+    render(<WaitlistMobileCard entry={guardianEntry} type="guardians" position={7} />);
+
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Gary Stubner' })).toHaveAttribute(
+      'href',
+      '/veterans/details?id=vet-2'
+    );
+    expect(screen.queryByText('Conflict')).not.toBeInTheDocument();
+    expect(screen.queryByText('Flight Group')).not.toBeInTheDocument();
+    // Active status renders no chip
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/main/waitlist/__tests__/waitlist-view.test.js
+++ b/src/components/main/waitlist/__tests__/waitlist-view.test.js
@@ -1,0 +1,155 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockReplace = jest.fn();
+const mockSearchParamsGet = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({
+    get: mockSearchParamsGet,
+  }),
+}));
+
+jest.mock('@/lib/api', () => ({
+  api: {
+    getWaitlist: jest.fn(),
+  },
+}));
+
+import { api } from '@/lib/api';
+import { WaitlistView } from '@/components/main/waitlist/waitlist-view';
+
+const makeVeteran = (overrides = {}) => ({
+  id: 'vet-1',
+  name: 'James Weimer',
+  age: 90,
+  city: 'Schiller Park',
+  appdate: '2024-07-25',
+  birth_date: '1935-04-01',
+  prefs: 'Guardian fee waiver',
+  status: 'Active',
+  vet_type: 'Korea',
+  group: '855-1',
+  pairings: [{ id: 'grd-9', name: 'James Weimer Jr' }],
+  ...overrides,
+});
+
+const makeGuardian = (overrides = {}) => ({
+  id: 'grd-1',
+  name: 'Rachel Stubner',
+  age: 56,
+  city: 'Menasha',
+  appdate: '2023-06-12',
+  birth_date: '1970-02-15',
+  prefs: 'Good for GRB',
+  status: 'Active',
+  vet_type: '',
+  group: '',
+  pairings: [{ id: 'vet-2', name: 'Gary Stubner' }],
+  ...overrides,
+});
+
+describe('WaitlistView', () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockSearchParamsGet.mockImplementation(() => null);
+    api.getWaitlist.mockReset();
+    api.getWaitlist.mockResolvedValue([makeVeteran()]);
+
+    // Force desktop layout (useMediaQuery -> matches false for down('sm'))
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  });
+
+  test('requests a page size of 100 (fetches 101 to detect more pages)', async () => {
+    render(<WaitlistView />);
+
+    await waitFor(() => {
+      expect(api.getWaitlist).toHaveBeenCalledWith({
+        type: 'veterans',
+        offset: 0,
+        limit: 101,
+      });
+    });
+  });
+
+  test('uses offset of 100 per page when page param is set', async () => {
+    mockSearchParamsGet.mockImplementation((key) => (key === 'page' ? '1' : null));
+
+    render(<WaitlistView />);
+
+    await waitFor(() => {
+      expect(api.getWaitlist).toHaveBeenCalledWith({
+        type: 'veterans',
+        offset: 100,
+        limit: 101,
+      });
+    });
+  });
+
+  test('renders veteran columns including Conflict, Flight Group and Guardian', async () => {
+    render(<WaitlistView />);
+
+    expect(await screen.findByText('James Weimer')).toBeInTheDocument();
+    for (const header of [
+      '#',
+      'Name',
+      'Age',
+      'Birth Date',
+      'City',
+      'Application Date',
+      'Conflict',
+      'Flight Group',
+      'Guardian',
+      'Notes',
+    ]) {
+      expect(screen.getByRole('columnheader', { name: header })).toBeInTheDocument();
+    }
+  });
+
+  test('renders guardian columns with Veteran(s) and without Conflict or Flight Group', async () => {
+    mockSearchParamsGet.mockImplementation((key) => (key === 'type' ? 'guardians' : null));
+    api.getWaitlist.mockResolvedValue([makeGuardian()]);
+
+    render(<WaitlistView />);
+
+    expect(await screen.findByText('Rachel Stubner')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Veteran(s)' })).toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Conflict' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: 'Flight Group' })).not.toBeInTheDocument();
+  });
+
+  test('numbers positions from the page offset', async () => {
+    mockSearchParamsGet.mockImplementation((key) => (key === 'page' ? '1' : null));
+    api.getWaitlist.mockResolvedValue([
+      makeVeteran(),
+      makeVeteran({ id: 'vet-2', name: 'Robert Molkentine' }),
+    ]);
+
+    render(<WaitlistView />);
+
+    expect(await screen.findByText('101')).toBeInTheDocument();
+    expect(screen.getByText('102')).toBeInTheDocument();
+  });
+
+  test('shows a status chip only for non-Active entries', async () => {
+    api.getWaitlist.mockResolvedValue([
+      makeVeteran(),
+      makeVeteran({ id: 'vet-2', name: 'Vernin Tretow', status: 'Future-Fall' }),
+    ]);
+
+    render(<WaitlistView />);
+
+    expect(await screen.findByText('Future-Fall')).toBeInTheDocument();
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/main/waitlist/waitlist-indicators.js
+++ b/src/components/main/waitlist/waitlist-indicators.js
@@ -1,0 +1,77 @@
+import Chip from '@mui/material/Chip';
+import { paths } from '@/paths';
+
+// The waitlist view only returns Active and Future-* statuses
+const STATUS_CHIP_COLORS = {
+  'Future-Spring': 'success',
+  'Future-Fall': 'warning',
+  'Future-PostRestriction': 'error',
+};
+
+// Soft color coding per conflict era; unlisted eras render neutral
+const CONFLICT_CHIP_STYLES = {
+  WWII: { bgcolor: '#fdf0c2', color: '#7a5d00' },
+  Korea: { bgcolor: '#d6e4ff', color: '#1d4ed8' },
+  Vietnam: { bgcolor: '#d8f3dc', color: '#1b6e3c' },
+};
+
+export function StatusChip({ status }) {
+  if (!status || status === 'Active') {
+    return null;
+  }
+  return (
+    <Chip
+      label={status}
+      size="small"
+      color={STATUS_CHIP_COLORS[status] || 'default'}
+      sx={{ fontWeight: 500 }}
+    />
+  );
+}
+
+export function ConflictChip({ vetType }) {
+  if (!vetType) {
+    return null;
+  }
+  const style = CONFLICT_CHIP_STYLES[vetType];
+  return (
+    <Chip
+      label={vetType}
+      size="small"
+      sx={{ fontWeight: 500, ...(style || {}) }}
+    />
+  );
+}
+
+export function PairingLinks({ pairings, type }) {
+  if (!pairings || pairings.length === 0) {
+    return '—';
+  }
+
+  // Veterans pair with guardians and vice versa
+  const detailPath = type === 'veterans'
+    ? paths.main.guardians.details
+    : paths.main.veterans.details;
+
+  return pairings.map((pairing, index) => (
+    <span key={`${pairing.id}-${index}`}>
+      {index > 0 && ', '}
+      {pairing.id ? (
+        <a
+          href={detailPath(pairing.id)}
+          style={{
+            color: 'var(--mui-palette-primary-main)',
+            textDecoration: 'none',
+            cursor: 'pointer'
+          }}
+          onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+          onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
+        >
+          {pairing.name}
+        </a>
+      ) : (
+        pairing.name
+      )}
+    </span>
+  ));
+}

--- a/src/components/main/waitlist/waitlist-item.js
+++ b/src/components/main/waitlist/waitlist-item.js
@@ -1,32 +1,13 @@
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
-import { User as UserIcon } from '@phosphor-icons/react/dist/ssr/User';
-import { MedalMilitary as MedalMilitaryIcon } from '@phosphor-icons/react/dist/ssr/MedalMilitary';
 import { dayjs } from '@/lib/dayjs';
 import { paths } from '@/paths';
+import { StatusChip, ConflictChip, PairingLinks } from '@/components/main/waitlist/waitlist-indicators';
 
-const getDurationIcon = (type) => {
-  if (type === 'veterans') {
-    return (
-      <Tooltip title="Veteran" arrow placement="top">
-        <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-          <MedalMilitaryIcon size="32" color="#b5ccf6" weight="fill" />
-        </span>
-      </Tooltip>
-    );
-  }
-  return (
-    <Tooltip title="Guardian" arrow placement="top">
-      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', paddingTop: '2px' }}>
-        <UserIcon size="32" color="#ff9999" weight="regular" />
-      </span>
-    </Tooltip>
-  );
-};
-
-export function WaitlistItem({ entry, type }) {
+export function WaitlistItem({ entry, type, position }) {
   const detailUrl = type === 'veterans' 
     ? paths.main.veterans.details(entry.id)
     : paths.main.guardians.details(entry.id);
@@ -36,39 +17,57 @@ export function WaitlistItem({ entry, type }) {
 
   return (
     <TableRow hover>
-      <TableCell sx={{ width: '50px' }}>
-        <Box 
-          sx={{
-            bgcolor: 'var(--mui-palette-background-level1)',
-            borderRadius: 1.5,
-            flex: '0 0 auto',
-            p: '4px 8px',
-            textAlign: 'center',
-            width: 50
-          }}
-        >
-          {getDurationIcon(type)}
-        </Box>
+      <TableCell sx={{ width: '60px' }}>
+        <Tooltip title={type === 'veterans' ? 'Veteran' : 'Guardian'} arrow placement="top">
+          <Box 
+            sx={{
+              bgcolor: 'var(--mui-palette-background-level1)',
+              borderRadius: 1.5,
+              flex: '0 0 auto',
+              p: '4px 8px',
+              textAlign: 'center',
+              fontWeight: 600,
+              width: 50
+            }}
+          >
+            {position}
+          </Box>
+        </Tooltip>
       </TableCell>
       <TableCell>
-        <a 
-          href={detailUrl}
-          style={{
-            color: 'var(--mui-palette-primary-main)',
-            fontWeight: '500',
-            textDecoration: 'none',
-            cursor: 'pointer'
-          }}
-          onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
-          onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
-        >
-          {entry.name}
-        </a>
+        <Stack spacing={0.5} sx={{ alignItems: 'flex-start' }}>
+          <a 
+            href={detailUrl}
+            style={{
+              color: 'var(--mui-palette-primary-main)',
+              fontWeight: '500',
+              textDecoration: 'none',
+              cursor: 'pointer'
+            }}
+            onMouseEnter={(e) => e.target.style.textDecoration = 'underline'}
+            onMouseLeave={(e) => e.target.style.textDecoration = 'none'}
+          >
+            {entry.name}
+          </a>
+          <StatusChip status={entry.status} />
+        </Stack>
       </TableCell>
       <TableCell>{entry.age !== null ? entry.age : '—'}</TableCell>
       <TableCell>{birthDate}</TableCell>
       <TableCell>{entry.city}</TableCell>
       <TableCell>{appDate}</TableCell>
+      {type === 'veterans' && (
+        <>
+          <TableCell>
+            <ConflictChip vetType={entry.vet_type} /> 
+            {!entry.vet_type && '—'}
+          </TableCell>
+          <TableCell>{entry.group || '—'}</TableCell>
+        </>
+      )}
+      <TableCell>
+        <PairingLinks pairings={entry.pairings} type={type} />
+      </TableCell>
       <TableCell sx={{ maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis' }}>
         {entry.prefs || '—'}
       </TableCell>

--- a/src/components/main/waitlist/waitlist-mobile-card.js
+++ b/src/components/main/waitlist/waitlist-mobile-card.js
@@ -5,31 +5,24 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
 import Tooltip from '@mui/material/Tooltip';
-import { User as UserIcon } from '@phosphor-icons/react/dist/ssr/User';
-import { MedalMilitary as MedalMilitaryIcon } from '@phosphor-icons/react/dist/ssr/MedalMilitary';
 import { dayjs } from '@/lib/dayjs';
 import { paths } from '@/paths';
+import { StatusChip, ConflictChip, PairingLinks } from '@/components/main/waitlist/waitlist-indicators';
 
-const getIcon = (type) => {
-  if (type === 'veterans') {
-    return (
-      <Tooltip title="Veteran" arrow placement="top">
-        <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-          <MedalMilitaryIcon size="24" color="#b5ccf6" weight="fill" />
-        </span>
-      </Tooltip>
-    );
-  }
+function DetailField({ label, children }) {
   return (
-    <Tooltip title="Guardian" arrow placement="top">
-      <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}>
-        <UserIcon size="24" color="#ff9999" weight="regular" />
-      </span>
-    </Tooltip>
+    <Stack spacing={0.25} sx={{ flex: 1 }}>
+      <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" component="div">
+        {children}
+      </Typography>
+    </Stack>
   );
-};
+}
 
-export function WaitlistMobileCard({ entry, type }) {
+export function WaitlistMobileCard({ entry, type, position }) {
   const detailUrl = type === 'veterans' 
     ? paths.main.veterans.details(entry.id)
     : paths.main.guardians.details(entry.id);
@@ -41,22 +34,25 @@ export function WaitlistMobileCard({ entry, type }) {
     <Card>
       <CardContent sx={{ '&:last-child': { pb: 2 } }}>
         <Stack spacing={2}>
-          {/* Header with icon and name */}
+          {/* Header with position and name */}
           <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
-            <Box 
-              sx={{
-                bgcolor: 'var(--mui-palette-background-level1)',
-                borderRadius: 1.5,
-                p: '4px 8px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minWidth: 40,
-                minHeight: 40,
-              }}
-            >
-              {getIcon(type)}
-            </Box>
+            <Tooltip title={type === 'veterans' ? 'Veteran' : 'Guardian'} arrow placement="top">
+              <Box 
+                sx={{
+                  bgcolor: 'var(--mui-palette-background-level1)',
+                  borderRadius: 1.5,
+                  p: '4px 8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  minWidth: 40,
+                  minHeight: 40,
+                  fontWeight: 600,
+                }}
+              >
+                {position}
+              </Box>
+            </Tooltip>
             <Stack spacing={0.5} sx={{ flex: 1 }}>
               <a 
                 href={detailUrl}
@@ -75,6 +71,10 @@ export function WaitlistMobileCard({ entry, type }) {
               <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                 {entry.city}
               </Typography>
+              <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                <StatusChip status={entry.status} />
+                {type === 'veterans' && <ConflictChip vetType={entry.vet_type} />}
+              </Box>
             </Stack>
           </Box>
 
@@ -83,32 +83,27 @@ export function WaitlistMobileCard({ entry, type }) {
           {/* Details rows */}
           <Stack spacing={1}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-              <Stack spacing={0.25} sx={{ flex: 1 }}>
-                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
-                  Age
-                </Typography>
-                <Typography variant="body2">
-                  {entry.age !== null ? entry.age : '—'}
-                </Typography>
-              </Stack>
-              <Stack spacing={0.25} sx={{ flex: 1 }}>
-                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
-                  Birth Date
-                </Typography>
-                <Typography variant="body2">
-                  {birthDate}
-                </Typography>
-              </Stack>
+              <DetailField label="Age">
+                {entry.age !== null ? entry.age : '—'}
+              </DetailField>
+              <DetailField label="Birth Date">
+                {birthDate}
+              </DetailField>
             </Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-              <Stack spacing={0.25} sx={{ flex: 1 }}>
-                <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary' }}>
-                  Application Date
-                </Typography>
-                <Typography variant="body2">
-                  {appDate}
-                </Typography>
-              </Stack>
+              <DetailField label="Application Date">
+                {appDate}
+              </DetailField>
+              {type === 'veterans' && (
+                <DetailField label="Group">
+                  {entry.group || '—'}
+                </DetailField>
+              )}
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+              <DetailField label={type === 'veterans' ? 'Guardian' : 'Veteran(s)'}>
+                <PairingLinks pairings={entry.pairings} type={type} />
+              </DetailField>
             </Box>
           </Stack>
 

--- a/src/components/main/waitlist/waitlist-view.js
+++ b/src/components/main/waitlist/waitlist-view.js
@@ -19,7 +19,7 @@ import { WaitlistTypeFilter } from '@/components/main/waitlist/waitlist-type-fil
 import { WaitlistItem } from '@/components/main/waitlist/waitlist-item';
 import { WaitlistMobileCard } from '@/components/main/waitlist/waitlist-mobile-card';
 
-const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 100;
 
 export function WaitlistView() {
   const searchParams = useSearchParams();
@@ -123,7 +123,12 @@ export function WaitlistView() {
         // Mobile Card View
         <Stack spacing={2} sx={{ p: 2 }}>
           {entries.map((entry, index) => (
-            <WaitlistMobileCard key={`${waitlistType}-${entry.id}-${index}`} entry={entry} type={waitlistType} />
+            <WaitlistMobileCard
+              key={`${waitlistType}-${entry.id}-${index}`}
+              entry={entry}
+              type={waitlistType}
+              position={offset + index + 1}
+            />
           ))}
         </Stack>
       ) : (
@@ -133,18 +138,32 @@ export function WaitlistView() {
             <Table>
               <TableHead>
                 <TableRow>
-                  <TableCell sx={{ fontWeight: 600, width: '50px' }}></TableCell>
+                  <TableCell sx={{ fontWeight: 600, width: '60px' }}>#</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Age</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Birth Date</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>City</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Application Date</TableCell>
+                  {waitlistType === 'veterans' ? (
+                    <>
+                      <TableCell sx={{ fontWeight: 600 }}>Conflict</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>Flight Group</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>Guardian</TableCell>
+                    </>
+                  ) : (
+                    <TableCell sx={{ fontWeight: 600 }}>Veteran(s)</TableCell>
+                  )}
                   <TableCell sx={{ fontWeight: 600 }}>Notes</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {entries.map((entry, index) => (
-                  <WaitlistItem key={`${waitlistType}-${entry.id}-${index}`} entry={entry} type={waitlistType} />
+                  <WaitlistItem
+                    key={`${waitlistType}-${entry.id}-${index}`}
+                    entry={entry}
+                    type={waitlistType}
+                    position={offset + index + 1}
+                  />
                 ))}
               </TableBody>
             </Table>

--- a/src/lib/__tests__/api-waitlist.test.js
+++ b/src/lib/__tests__/api-waitlist.test.js
@@ -104,6 +104,19 @@ describe('api.getWaitlist', () => {
     expect(entry.prefs).toBe('Call notes here | Guardian fee waiver.mm');
   });
 
+  test('formats names as simple "First Last", ignoring nickname and middle name', async () => {
+    mockFetchWith([
+      {
+        ...mockVeteran,
+        name: { first: 'James', middle: 'Robert', last: 'Weimer', nickname: 'Jim' },
+      },
+    ]);
+
+    const result = await api.getWaitlist({ type: 'veterans' });
+
+    expect(result[0].name).toBe('James Weimer');
+  });
+
   test('veteran without a paired guardian yields empty pairings', async () => {
     mockFetchWith([{ ...mockVeteran, guardian: { id: '', name: '' } }]);
 

--- a/src/lib/__tests__/api-waitlist.test.js
+++ b/src/lib/__tests__/api-waitlist.test.js
@@ -1,0 +1,139 @@
+import { api } from '@/lib/api';
+import { toast } from '@/components/core/toaster';
+
+jest.mock('@/components/core/toaster', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/auth/domain/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn().mockResolvedValue('test-token'),
+    getRefreshToken: jest.fn(),
+    refreshToken: jest.fn(),
+    clearTokens: jest.fn(),
+  },
+}));
+
+const mockVeteran = {
+  _id: 'vet-1',
+  type: 'Veteran',
+  name: { first: 'James', middle: '', last: 'Weimer', nickname: '' },
+  birth_date: '1935-04-01',
+  vet_type: 'Korea',
+  app_date: '2024-07-25',
+  address: { city: 'Schiller Park' },
+  flight: { status: 'Future-Fall', group: '855-1', status_note: 'Guardian fee waiver.mm' },
+  call: { notes: 'Call notes here' },
+  guardian: { id: 'grd-9', name: 'James Weimer Jr' },
+};
+
+const mockGuardian = {
+  _id: 'grd-1',
+  type: 'Guardian',
+  name: { first: 'Rachel', middle: '', last: 'Stubner', nickname: '' },
+  birth_date: '1970-02-15',
+  app_date: '2023-06-12',
+  address: { city: 'Menasha' },
+  flight: { status: 'Active' },
+  notes: { other: 'Prefers fall flight' },
+  medical: { experience: 'RN for 20 years' },
+  veteran: {
+    pairings: [
+      { id: 'vet-2', name: 'Gary Stubner' },
+      { id: 'vet-3', name: 'Vernin Tretow' },
+    ],
+  },
+};
+
+describe('api.getWaitlist', () => {
+  let fetchMock;
+
+  const mockFetchWith = (data) => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    });
+    global.fetch = fetchMock;
+  };
+
+  beforeEach(() => {
+    toast.error.mockClear();
+  });
+
+  test('sends type, offset and limit query params with default limit of 100', async () => {
+    mockFetchWith([]);
+
+    await api.getWaitlist();
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('/waitlist?');
+    expect(url).toContain('type=veterans');
+    expect(url).toContain('offset=0');
+    expect(url).toContain('limit=100');
+  });
+
+  test('passes through explicit pagination params', async () => {
+    mockFetchWith([]);
+
+    await api.getWaitlist({ type: 'guardians', offset: 100, limit: 101 });
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('type=guardians');
+    expect(url).toContain('offset=100');
+    expect(url).toContain('limit=101');
+  });
+
+  test('transforms veteran entries with status, conflict, group and guardian pairing', async () => {
+    mockFetchWith([mockVeteran]);
+
+    const result = await api.getWaitlist({ type: 'veterans' });
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry.id).toBe('vet-1');
+    // vet_type is no longer appended to the name; it is its own field
+    expect(entry.name).toBe('James Weimer');
+    expect(entry.vet_type).toBe('Korea');
+    expect(entry.status).toBe('Future-Fall');
+    expect(entry.group).toBe('855-1');
+    expect(entry.pairings).toEqual([{ id: 'grd-9', name: 'James Weimer Jr' }]);
+    expect(entry.city).toBe('Schiller Park');
+    expect(entry.appdate).toBe('2024-07-25');
+    expect(entry.prefs).toBe('Call notes here | Guardian fee waiver.mm');
+  });
+
+  test('veteran without a paired guardian yields empty pairings', async () => {
+    mockFetchWith([{ ...mockVeteran, guardian: { id: '', name: '' } }]);
+
+    const result = await api.getWaitlist({ type: 'veterans' });
+
+    expect(result[0].pairings).toEqual([]);
+  });
+
+  test('transforms guardian entries with status and veteran pairings', async () => {
+    mockFetchWith([mockGuardian]);
+
+    const result = await api.getWaitlist({ type: 'guardians' });
+
+    const entry = result[0];
+    expect(entry.id).toBe('grd-1');
+    expect(entry.name).toBe('Rachel Stubner');
+    expect(entry.status).toBe('Active');
+    expect(entry.pairings).toEqual([
+      { id: 'vet-2', name: 'Gary Stubner' },
+      { id: 'vet-3', name: 'Vernin Tretow' },
+    ]);
+    // Guardian notes still merge notes.other and medical.experience (covers Med. Training)
+    expect(entry.prefs).toBe('Prefers fall flight | RN for 20 years');
+  });
+
+  test('shows toast error and rethrows on failure', async () => {
+    fetchMock = jest.fn().mockRejectedValue(new Error('Network error'));
+    global.fetch = fetchMock;
+
+    await expect(api.getWaitlist()).rejects.toThrow('Network error');
+    expect(toast.error).toHaveBeenCalledWith('Failed to fetch waitlist: Network error');
+  });
+});

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -506,15 +506,10 @@ class ApiClient {
           prefs = [callNotes, statusNote].filter(Boolean).join(' | ');
         }
 
-        // Format name: if nickname exists, use "Nickname: First Middle Last", otherwise just "First Middle Last"
+        // Format name as a simple "First Last" (no nickname or middle name)
         let formattedName = entry.name;
         if (typeof entry.name === 'object') {
-          const fullName = `${entry.name?.first || ''} ${entry.name?.middle ? `${entry.name.middle} ` : ''}${entry.name?.last || ''}`.trim();
-          if (entry.name?.nickname) {
-            formattedName = `${entry.name.nickname}: ${fullName}`;
-          } else {
-            formattedName = fullName;
-          }
+          formattedName = `${entry.name?.first || ''} ${entry.name?.last || ''}`.trim();
         }
 
         // Pairing names: veterans have a single guardian, guardians have veteran pairings

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -475,7 +475,7 @@ class ApiClient {
   }
 
   // Get waitlist
-  async getWaitlist({ type = 'veterans', offset = 0, limit = 20 } = {}) {
+  async getWaitlist({ type = 'veterans', offset = 0, limit = 100 } = {}) {
     try {
       const queryParams = new URLSearchParams();
       
@@ -507,7 +507,6 @@ class ApiClient {
         }
 
         // Format name: if nickname exists, use "Nickname: First Middle Last", otherwise just "First Middle Last"
-        // For veterans, add vet_type in parentheses
         let formattedName = entry.name;
         if (typeof entry.name === 'object') {
           const fullName = `${entry.name?.first || ''} ${entry.name?.middle ? `${entry.name.middle} ` : ''}${entry.name?.last || ''}`.trim();
@@ -517,10 +516,15 @@ class ApiClient {
             formattedName = fullName;
           }
         }
-        
-        // Add vet_type for veterans
-        if (type === 'veterans' && entry.vet_type) {
-          formattedName = `${formattedName} (${entry.vet_type})`;
+
+        // Pairing names: veterans have a single guardian, guardians have veteran pairings
+        let pairings = [];
+        if (type === 'guardians') {
+          pairings = (entry.veteran?.pairings || [])
+            .filter((pairing) => pairing?.name)
+            .map((pairing) => ({ id: pairing.id || '', name: pairing.name }));
+        } else if (entry.guardian?.name) {
+          pairings = [{ id: entry.guardian.id || '', name: entry.guardian.name }];
         }
 
         // Calculate age from birth_date
@@ -544,6 +548,10 @@ class ApiClient {
           appdate: entry.app_date || '',
           birth_date: entry.birth_date || '',
           prefs,
+          status: entry.flight?.status || '',
+          vet_type: type === 'veterans' ? entry.vet_type || '' : '',
+          group: type === 'veterans' ? entry.flight?.group || '' : '',
+          pairings,
         };
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Implements #127 — adds the requested data to the waitlist displays and increases the page size.

- Position: computed from waitlist order (offset + row index + 1), shown in a badge replacing the per-row type icon
- Status: color-coded chip under the name, only when not Active (Future-Spring green, Future-Fall orange, Future-PostRestriction red)
- Pairing Name: veteran's guardian / guardian's veteran(s), rendered as links to the paired record's detail page
- Conflict (veterans): color-coded chip in its own column (WWII gold, Korea blue, Vietnam green), removed from the name string
- Flight Group (veterans): new column from flight.group
- Med. Training (guardians): already covered via the merged guardian Notes (notes.other + medical.experience)
- Page size increased from 20 to 100
- Name column simplified to "First Last" (no nickname prefix or middle name)
- Mobile cards updated with the same fields

Closes #127

## Test plan

- [x] New Jest/RTL tests: `api.getWaitlist` transform, `WaitlistView` columns/pagination, `WaitlistItem` rows, `WaitlistMobileCard`
- [x] Full suite passes (23 suites, 132 tests)
- [x] Verify mobile layout on the deployed environment
