### PR TITLE
Add production environment deployment for UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env.local for local development:
+#   cp .env.example .env.local
+#
+# These NEXT_PUBLIC_* values are inlined into the client bundle at build time.
+# They are not secrets (they ship to the browser). For Cloud Run, CI passes
+# them via GitHub Actions variables — see docs/DEPLOYMENT.md.
+
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=330507742215-scerc6p0lvou59tufmohq1b7b4bj0l90.apps.googleusercontent.com
+NEXT_PUBLIC_ROLE_FULL_ACCESS=sshf_app_dev_full_access@starsandstripeshonorflight.org
+NEXT_PUBLIC_API_URL=https://sshf-api-330507742215.us-central1.run.app
+NEXT_PUBLIC_ENVIRONMENT=Development
+
+# Server-only (never commit a real value). Required for the local OAuth
+# token exchange routes under src/app/api/auth/.
+# GOOGLE_CLIENT_SECRET=

--- a/.env.local
+++ b/.env.local
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_GOOGLE_CLIENT_ID=330507742215-scerc6p0lvou59tufmohq1b7b4bj0l90.apps.googleusercontent.com
-NEXT_PUBLIC_ROLE_FULL_ACCESS=sshf_app_dev_full_access@starsandstripeshonorflight.org
-NEXT_PUBLIC_API_URL=https://sshf-api-330507742215.us-central1.run.app

--- a/.github/workflows/cloudrun-release-prd.yml
+++ b/.github/workflows/cloudrun-release-prd.yml
@@ -1,0 +1,171 @@
+name: Release to Cloud Run Production
+
+# Next.js inlines NEXT_PUBLIC_* at build time, so production cannot promote a
+# digests from the dev image. This workflow source-builds the tagged commit
+# into sshf-ui-prd with production build variables.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Existing git tag to deploy (e.g. v1.0.0)'
+        required: true
+
+concurrency: production-deploy
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  SERVICE_NAME: ${{ secrets.GCP_SERVICE_NAME }}
+  REGION: ${{ secrets.GCP_REGION }}
+  WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+  # Runtime SA email (not secret). Set as a production environment variable.
+  RUNTIME_SERVICE_ACCOUNT: ${{ vars.GCP_RUNTIME_SERVICE_ACCOUNT }}
+  # Production client build values from the "production" environment Variables.
+  NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+  NEXT_PUBLIC_ROLE_FULL_ACCESS: ${{ vars.NEXT_PUBLIC_ROLE_FULL_ACCESS }}
+  NEXT_PUBLIC_ENVIRONMENT: ${{ vars.NEXT_PUBLIC_ENVIRONMENT }}
+  # Hard-coded known-bad value for the smoke-test negative check.
+  DEV_API_URL: https://sshf-api-330507742215.us-central1.run.app
+
+jobs:
+  release:
+    runs-on: 'ubuntu-latest'
+    # Requires the "production" GitHub environment (approval gate +
+    # environment-scoped GCP_* secrets pointing at sshf-ui-prd).
+    environment: 'production'
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: 'Checkout release tag'
+        uses: 'actions/checkout@v4'
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: 'Resolve version'
+        id: 'version'
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            git checkout --force "$VERSION"
+          else
+            VERSION="${{ inputs.version }}"
+            git checkout --force "$VERSION"
+          fi
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '$VERSION' must be a semver tag like v1.2.3"
+            exit 1
+          fi
+          # Cloud Run revision tags cannot contain dots.
+          REVISION_TAG="${VERSION//./-}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "revision_tag=$REVISION_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: 'Validate client build environment'
+        run: node scripts/check-build-env.mjs
+
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v3'
+        with:
+          workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ env.SERVICE_ACCOUNT }}'
+          token_format: 'access_token'
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v3'
+
+      - name: 'Configure client build environment'
+        run: |
+          cat > .env.production <<EOF
+          NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID=${NEXT_PUBLIC_GOOGLE_CLIENT_ID}
+          NEXT_PUBLIC_ROLE_FULL_ACCESS=${NEXT_PUBLIC_ROLE_FULL_ACCESS}
+          NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT}
+          EOF
+          sed -i 's/^[[:space:]]*//' .env.production
+          cat .env.production
+
+      - name: 'Deploy to Cloud Run (no traffic)'
+        id: 'deploy'
+        uses: 'google-github-actions/deploy-cloudrun@v3'
+        with:
+          project_id: '${{ env.PROJECT_ID }}'
+          service: '${{ env.SERVICE_NAME }}'
+          region: '${{ env.REGION }}'
+          source: './'
+          no_traffic: true
+          tag: '${{ steps.version.outputs.revision_tag }}'
+          secrets: |
+            GOOGLE_CLIENT_SECRET=${{ secrets.GCP_SECRET_NAME }}:latest
+          flags: '--service-account=${{ env.RUNTIME_SERVICE_ACCOUNT }} --update-build-env-vars=NEXT_PUBLIC_API_URL=${{ env.NEXT_PUBLIC_API_URL }},NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }},NEXT_PUBLIC_ROLE_FULL_ACCESS=${{ env.NEXT_PUBLIC_ROLE_FULL_ACCESS }},NEXT_PUBLIC_ENVIRONMENT=${{ env.NEXT_PUBLIC_ENVIRONMENT }}'
+
+      - name: 'Smoke test tagged revision'
+        run: |
+          TAG="${{ steps.version.outputs.revision_tag }}"
+          TAG_URL=$(gcloud run services describe "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --format json \
+            | jq -r --arg t "$TAG" '.status.traffic[] | select(.tag==$t) | .url')
+          if [[ -z "$TAG_URL" || "$TAG_URL" == "null" ]]; then
+            echo "::error::Could not resolve URL for revision tag $TAG"
+            exit 1
+          fi
+          echo "Smoke testing $TAG_URL"
+          curl -fsSL --retry 5 --retry-delay 10 "$TAG_URL/" -o /tmp/sshf-ui-home.html
+          # Confirm the production API URL is present in the served document
+          # graph and the known-dev API URL is absent.
+          if ! grep -qF "${NEXT_PUBLIC_API_URL}" /tmp/sshf-ui-home.html; then
+            # Next may put the value in a chunk referenced by the HTML; fetch
+            # a few linked scripts and search those too.
+            FOUND=0
+            for SRC in $(grep -oE '/_next/static/[^"]+\.js' /tmp/sshf-ui-home.html | head -n 20); do
+              curl -fsSL "${TAG_URL}${SRC}" -o /tmp/chunk.js || continue
+              if grep -qF "${NEXT_PUBLIC_API_URL}" /tmp/chunk.js; then
+                FOUND=1
+                break
+              fi
+            done
+            if [[ "$FOUND" -ne 1 ]]; then
+              echo "::error::Prod API URL not found in served bundle"
+              exit 1
+            fi
+          fi
+          if grep -qF "${DEV_API_URL}" /tmp/sshf-ui-home.html; then
+            echo "::error::Dev API URL leaked into production bundle HTML"
+            exit 1
+          fi
+          for SRC in $(grep -oE '/_next/static/[^"]+\.js' /tmp/sshf-ui-home.html | head -n 20); do
+            curl -fsSL "${TAG_URL}${SRC}" -o /tmp/chunk.js || continue
+            if grep -qF "${DEV_API_URL}" /tmp/chunk.js; then
+              echo "::error::Dev API URL leaked into production bundle script ${SRC}"
+              exit 1
+            fi
+          done
+          echo "Smoke test passed"
+
+      - name: 'Shift 100% traffic to new revision'
+        run: |
+          gcloud run services update-traffic "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" --to-latest
+
+      # Idempotent: required for the first bootstrap deploy; harmless afterward.
+      - name: 'Ensure public invoker'
+        run: |
+          gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" \
+            --member="allUsers" --role="roles/run.invoker" \
+            --quiet
+
+      - name: 'Show output'
+        run: |-
+          echo "Released ${{ steps.version.outputs.version }} to production"
+          echo ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/cloudrun-source.yml
+++ b/.github/workflows/cloudrun-source.yml
@@ -13,6 +13,12 @@ env:
   REGION: ${{ secrets.GCP_REGION }}
   WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+  # Client build values from repo Variables (Settings → Secrets and variables → Actions → Variables).
+  # These are public by design (inlined into the Next.js client bundle at build time).
+  NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ vars.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
+  NEXT_PUBLIC_ROLE_FULL_ACCESS: ${{ vars.NEXT_PUBLIC_ROLE_FULL_ACCESS }}
+  NEXT_PUBLIC_ENVIRONMENT: ${{ vars.NEXT_PUBLIC_ENVIRONMENT }}
 
 jobs:
   deploy:
@@ -35,13 +41,17 @@ jobs:
           echo "Region length: ${#REGION}"
           echo "WIP length: ${#WORKLOAD_IDENTITY_PROVIDER}"
           echo "Service Account length: ${#SERVICE_ACCOUNT}"
-          
-          # Check if any are empty
+          echo "NEXT_PUBLIC_ENVIRONMENT: ${NEXT_PUBLIC_ENVIRONMENT}"
+          echo "NEXT_PUBLIC_API_URL length: ${#NEXT_PUBLIC_API_URL}"
+
           [[ -z "$PROJECT_ID" ]] && echo "⚠️ PROJECT_ID is empty" || echo "✓ PROJECT_ID is set"
           [[ -z "$SERVICE_NAME" ]] && echo "⚠️ SERVICE_NAME is empty" || echo "✓ SERVICE_NAME is set"
           [[ -z "$REGION" ]] && echo "⚠️ REGION is empty" || echo "✓ REGION is set"
           [[ -z "$WORKLOAD_IDENTITY_PROVIDER" ]] && echo "⚠️ WIP is empty" || echo "✓ WIP is set"
           [[ -z "$SERVICE_ACCOUNT" ]] && echo "⚠️ SERVICE_ACCOUNT is empty" || echo "✓ SERVICE_ACCOUNT is set"
+
+      - name: 'Validate client build environment'
+        run: node scripts/check-build-env.mjs
 
       # Configure Workload Identity Federation and generate an access token.
       #
@@ -49,7 +59,7 @@ jobs:
       # including authenticating via a JSON credentials file.
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           workload_identity_provider: '${{ env.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ env.SERVICE_ACCOUNT }}'
@@ -58,23 +68,37 @@ jobs:
           export_environment_variables: true
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
+
+      # NEXT_PUBLIC_* is inlined at next build time. Write them into .env.production
+      # so Buildpacks / next build see them, and also pass --update-build-env-vars.
+      - name: 'Configure client build environment'
+        run: |
+          cat > .env.production <<EOF
+          NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+          NEXT_PUBLIC_GOOGLE_CLIENT_ID=${NEXT_PUBLIC_GOOGLE_CLIENT_ID}
+          NEXT_PUBLIC_ROLE_FULL_ACCESS=${NEXT_PUBLIC_ROLE_FULL_ACCESS}
+          NEXT_PUBLIC_ENVIRONMENT=${NEXT_PUBLIC_ENVIRONMENT}
+          EOF
+          # Trim accidental leading whitespace from the heredoc lines.
+          sed -i 's/^[[:space:]]*//' .env.production
+          cat .env.production
 
       - name: 'Deploy to Cloud Run'
         id: 'deploy'
-        uses: 'google-github-actions/deploy-cloudrun@v2'
+        uses: 'google-github-actions/deploy-cloudrun@v3'
         with:
           project_id: '${{ env.PROJECT_ID }}'
           service: '${{ env.SERVICE_NAME }}'
           region: '${{ env.REGION }}'
-          # NOTE: If using a different source folder, update the image name below:
           source: './'
           # Reference secret from Google Secret Manager (must already exist in GCP)
           secrets: |
             GOOGLE_CLIENT_SECRET=${{ secrets.GCP_SECRET_NAME }}:latest
+          # Build-time for Next.js client bundle.
+          flags: >-
+            --update-build-env-vars=NEXT_PUBLIC_API_URL=${{ env.NEXT_PUBLIC_API_URL }},NEXT_PUBLIC_GOOGLE_CLIENT_ID=${{ env.NEXT_PUBLIC_GOOGLE_CLIENT_ID }},NEXT_PUBLIC_ROLE_FULL_ACCESS=${{ env.NEXT_PUBLIC_ROLE_FULL_ACCESS }},NEXT_PUBLIC_ENVIRONMENT=${{ env.NEXT_PUBLIC_ENVIRONMENT }}
 
-      # If required, use the Cloud Run URL output in later steps
       - name: 'Show output'
         run: |-
           echo ${{ steps.deploy.outputs.url }}
-

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ out/
 junit.xml
 
 .env
+.env.local
+.env.*.local
 .DS_Store
 *.swp
 *~

--- a/README.md
+++ b/README.md
@@ -2,13 +2,29 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+1. Copy the example env file and fill in a local `GOOGLE_CLIENT_SECRET` if you
+   need the OAuth sign-in flow:
 
 ```bash
+cp .env.example .env.local
+```
+
+`.env.local` is gitignored. The four `NEXT_PUBLIC_*` values in `.env.example`
+are the development defaults (API URL, Google client ID, full-access group,
+and `NEXT_PUBLIC_ENVIRONMENT=Development`). Without them the client will not
+point at a backend — there is no hardcoded API fallback.
+
+2. Install dependencies and start the development server:
+
+```bash
+npm install
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+Before a Cloud Run deploy, CI runs `npm run check-build-env` to ensure the four
+`NEXT_PUBLIC_*` build variables are set.
 
 ## Schema sync (OpenAPI → Zod)
 
@@ -61,36 +77,43 @@ Key generated models include `Veteran`, `Guardian`, `Flight`, flight-detail/assi
 
 ## Deployment
 
-This project is deployed to Google Cloud Run via GitHub Actions. The deployment workflow (`.github/workflows/cloudrun-source.yml`) runs automatically when a pull request is merged to the `main` branch.
+This project deploys to Google Cloud Run via GitHub Actions:
 
-### Required GitHub Secrets
+- **Development** — merge to `main` runs `.github/workflows/cloudrun-source.yml`
+  (source deploy into `sshf-ui-dev`).
+- **Production** — publishing a GitHub Release `vX.Y.Z` runs
+  `.github/workflows/cloudrun-release-prd.yml` (source deploy into
+  `sshf-ui-prd` behind a `production` environment approval gate).
 
-Configure these secrets in GitHub repository settings (`Settings > Secrets and variables > Actions`):
+Because Next.js inlines `NEXT_PUBLIC_*` at build time, each environment builds
+from source with its own GitHub Actions variables. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)
+for the full pipeline, secrets, and release process.
+
+### Required GitHub configuration
+
+**Repository secrets** (dev deploy):
 
 | Secret Name | Description | Example |
 |-------------|-------------|---------|
-| `GCP_PROJECT_ID` | Your GCP project ID | `sshf-ui-dev` |
+| `GCP_PROJECT_ID` | GCP project ID | `sshf-ui-dev` |
 | `GCP_SERVICE_NAME` | Cloud Run service name | `sshf-ui` |
-| `GCP_REGION` | GCP region for deployment | `us-central1` |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Provider path | `projects/123456789/locations/global/workloadIdentityPools/github-pool/providers/github` |
-| `GCP_SERVICE_ACCOUNT` | Service account email for deployment | `github-actions@sshf-ui-dev.iam.gserviceaccount.com` |
-| `GCP_SECRET_NAME` | Name of Google Secret Manager secret | `sshf-ui-google-client-secret-dev` |
+| `GCP_REGION` | GCP region | `us-central1` |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Provider path | `projects/.../providers/...` |
+| `GCP_SERVICE_ACCOUNT` | Deploy service account email | `...@sshf-ui-dev.iam.gserviceaccount.com` |
+| `GCP_SECRET_NAME` | Secret Manager secret for `GOOGLE_CLIENT_SECRET` | `sshf-ui-google-client-secret-dev` |
 
-### Google Secret Manager
+**Repository variables** (dev client build):
 
-The `GOOGLE_CLIENT_SECRET` is pulled from Google Secret Manager at runtime (not stored in GitHub). Ensure the secret exists in your GCP project and the Cloud Run service account has access to it.
+| Variable | Example |
+|----------|---------|
+| `NEXT_PUBLIC_API_URL` | `https://sshf-api-330507742215.us-central1.run.app` |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `....apps.googleusercontent.com` |
+| `NEXT_PUBLIC_ROLE_FULL_ACCESS` | `sshf_app_dev_full_access@starsandstripeshonorflight.org` |
+| `NEXT_PUBLIC_ENVIRONMENT` | `Development` |
 
-### GCP Setup
-
-If you're reusing an existing Workload Identity Pool from another project (e.g., sshf-api), you may need to update the pool's attribute condition to include this repository:
-
-```bash
-gcloud iam workload-identity-pools providers update "github" \
-  --project="YOUR_PROJECT_ID" \
-  --location="global" \
-  --workload-identity-pool="github-pool" \
-  --attribute-condition="assertion.repository_owner == 'YOUR_GITHUB_ORG' && assertion.repository in ['YOUR_ORG/sshf-api', 'YOUR_ORG/sshf-ui']"
-```
+Production uses the GitHub `production` environment with the same secret/variable
+names scoped to `sshf-ui-prd` and production values. Only `GOOGLE_CLIENT_SECRET`
+is a real secret (Secret Manager); the `NEXT_PUBLIC_*` values are public by design.
 
 ## Learn More
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,246 @@
+# CI/CD and Deployment Guide
+
+This document describes the path code takes from a developer's branch to
+production for **sshf-ui**, what must be configured per environment, how a
+release is built into production, and how to verify and roll back. It is
+written for both developers and administrators.
+
+## Environments
+
+| | Development | Production |
+|---|---|---|
+| GCP project | `sshf-ui-dev` | `sshf-ui-prd` |
+| Service URL | https://sshf-ui-593951006010.us-central1.run.app | https://sshf-ui-824787296892.us-central1.run.app |
+| Cloud Run service | `sshf-ui` (us-central1) | `sshf-ui` (us-central1) |
+| Runtime service account | `sshf-ui@sshf-ui-dev.iam.gserviceaccount.com` | `sshf-ui-acc-prd@sshf-ui-prd.iam.gserviceaccount.com` |
+| Deploy service account | (dev SA / WIF via sshf-api-dev pool) | `github-service-account@sshf-ui-prd.iam.gserviceaccount.com` |
+| Deployed by | Merge to `main` | Published GitHub Release (with approval) |
+| Client build config | Repo Actions **variables** | `production` environment **variables** |
+| Runtime secret | `sshf-ui-google-client-secret-dev` | `sshf-ui-google-client-secret-prd` |
+
+Both services are publicly invokable; authentication happens inside the
+application (Google OAuth popup → Next.js `/api/auth/*` token exchange → API
+bearer token). Group checks are performed by the API, not the UI.
+
+## Critical difference from sshf-api
+
+sshf-api builds once in dev and promotes the exact image digest to production.
+**sshf-ui cannot do that.** Next.js inlines `NEXT_PUBLIC_*` into the client
+bundle at `next build` time, so an image built with development values will
+always talk to the development API.
+
+Production therefore **source-builds the tagged commit** into `sshf-ui-prd`
+with production build variables. You lose binary-identical promotion; you keep
+versioned releases, an approval gate, and environment isolation.
+
+```mermaid
+flowchart LR
+    pr[Pull request] --> tests[run-tests.yml]
+    tests --> merge[Merge to main]
+    merge --> devDeploy[cloudrun-source.yml: source deploy to sshf-ui-dev]
+    release[GitHub Release vX.Y.Z] --> gate[production environment approval]
+    gate --> prodDeploy[cloudrun-release-prd.yml]
+    prodDeploy --> build[Source build with prod NEXT_PUBLIC_*]
+    build --> noTraffic[Deploy revision with no traffic]
+    noTraffic --> smoke[Smoke test tagged URL + bundle check]
+    smoke --> shift[Shift 100 percent traffic]
+```
+
+Workflows involved (all in `.github/workflows/`):
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `run-tests.yml` | Pull request to `main` | Installs dependencies and runs Jest |
+| `cloudrun-source.yml` | PR merged to `main` (or manual dispatch) | Source-deploys to dev Cloud Run with dev build vars |
+| `cloudrun-release-prd.yml` | GitHub Release published (or manual dispatch) | Source-deploys the tagged commit to prod behind approval |
+
+## Client build variables
+
+These four values are **public** (they ship in the browser bundle). They are
+**not** stored in Secret Manager. CI reads them from GitHub Actions variables
+and writes them to `.env.production` / `--update-build-env-vars` before the
+Cloud Run source build. `scripts/check-build-env.mjs` fails the workflow if
+any are missing.
+
+| Variable | Development | Production |
+|---|---|---|
+| `NEXT_PUBLIC_API_URL` | `https://sshf-api-330507742215.us-central1.run.app` | `https://sshf-api-928260206537.us-central1.run.app` |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Dev OAuth client ID | Prod OAuth client ID (same client as prod API) |
+| `NEXT_PUBLIC_ROLE_FULL_ACCESS` | `sshf_app_dev_full_access@starsandstripeshonorflight.org` | `sshf_app_prd_full_access@starsandstripeshonorflight.org` |
+| `NEXT_PUBLIC_ENVIRONMENT` | `Development` | `Production` |
+
+`NEXT_PUBLIC_ENVIRONMENT` drives the warning banner in the nav and sign-in
+form: the banner is hidden only when the value is `Production` (case-
+insensitive). Local development copies these values from `.env.example` into
+a gitignored `.env.local`.
+
+The only **real** secret is `GOOGLE_CLIENT_SECRET`, mounted from Secret Manager
+onto the Cloud Run service at runtime for the OAuth token exchange routes.
+
+## For developers: during development
+
+1. Branch from `main`, make changes with tests, and open a PR. The test
+   workflow must pass before merge.
+2. Copy `.env.example` to `.env.local` for local runs. There is **no** hardcoded
+   API URL fallback — without `NEXT_PUBLIC_API_URL` the client has no backend.
+3. **Never commit `.env.local`.** Never hardcode environment-specific client
+   IDs or API URLs in source.
+4. Merging to `main` automatically deploys to dev. Verify on the dev service
+   before considering a change releasable.
+
+## Preparing a release
+
+1. Decide the new semver version `vX.Y.Z` (patch / minor / major).
+2. Update `package.json` `"version"` via a normal PR if you want the UI version
+   to match the release tag.
+3. Merge and let the **dev** deploy finish. Sanity-check
+   https://sshf-ui-593951006010.us-central1.run.app — banner should say
+   DEVELOPMENT, and sign-in should reach the **dev** API.
+
+## Releasing to production
+
+1. In GitHub: **Releases → Draft a new release**. Create a new tag `vX.Y.Z`
+   targeting `main` (must match `v[0-9]+.[0-9]+.[0-9]+`). Write brief release
+   notes and **Publish**.
+2. The `Release to Cloud Run Production` workflow starts and pauses at the
+   `production` environment gate. A required reviewer approves it under
+   **Actions → the running workflow → Review deployments**.
+3. After approval the workflow, running as the prod deploy service account via
+   Workload Identity Federation:
+   1. Checks out the release tag.
+   2. Validates the four `NEXT_PUBLIC_*` production variables.
+   3. Source-deploys into `sshf-ui-prd` with **no traffic** and a revision tag
+      (`v1-2-3` — dots become dashes).
+   4. Smoke-tests the tagged revision URL (HTTP 200 on `/`, production API URL
+      present in the served bundle, development API URL absent).
+   5. Shifts 100% of traffic to the new revision.
+
+If any step fails, production traffic remains on the previous revision.
+
+### Manual promotion
+
+**Actions → Release to Cloud Run Production → Run workflow**, entering an
+existing tag (e.g. `v1.0.0`). Useful for re-deploying an older tag (see
+Rollback).
+
+## Post-release verification
+
+1. **Workflow green** — smoke test and traffic shift succeeded.
+2. **No development banner** on https://sshf-ui-824787296892.us-central1.run.app
+3. **Sign-in** reaches Google with the **production** OAuth client, and API
+   calls hit `https://sshf-api-928260206537.us-central1.run.app` (CORS already
+   allows the prod UI origin on the API).
+
+Administrators can confirm from the CLI:
+
+```bash
+gcloud run services describe sshf-ui --region us-central1 --project sshf-ui-prd \
+  --format "value(status.latestReadyRevisionName, status.traffic, status.url)"
+
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=sshf-ui AND severity>=ERROR" \
+  --project sshf-ui-prd --freshness=1h --limit 20
+```
+
+## Rollback
+
+1. **Shift traffic back** (fastest):
+
+```bash
+gcloud run revisions list --service sshf-ui --region us-central1 --project sshf-ui-prd
+gcloud run services update-traffic sshf-ui --region us-central1 --project sshf-ui-prd \
+  --to-revisions <previous-revision-name>=100
+```
+
+2. **Re-run the release workflow** with a previous tag. That rebuilds from the
+   tagged source with current production variables (not an image digest copy).
+
+## Configuration (administrators)
+
+### GitHub
+
+| Scope | Name | Purpose |
+|---|---|---|
+| Repo secret | `GCP_PROJECT_ID` | `sshf-ui-dev` |
+| Repo secret | `GCP_SERVICE_NAME` | `sshf-ui` |
+| Repo secret | `GCP_REGION` | `us-central1` |
+| Repo secret | `GCP_WORKLOAD_IDENTITY_PROVIDER` | Dev WIF provider resource name |
+| Repo secret | `GCP_SERVICE_ACCOUNT` | Dev deploy SA email |
+| Repo secret | `GCP_SECRET_NAME` | `sshf-ui-google-client-secret-dev` |
+| Repo variable | `NEXT_PUBLIC_*` (four) | Dev client build values |
+| Env `production` secret | same `GCP_*` names | Prod project / WIF / deploy SA / `sshf-ui-google-client-secret-prd` |
+| Env `production` variable | `NEXT_PUBLIC_*` (four) | Prod client build values |
+| Env `production` variable | `GCP_RUNTIME_SERVICE_ACCOUNT` | `sshf-ui-acc-prd@sshf-ui-prd.iam.gserviceaccount.com` |
+
+The `production` environment has a required reviewer (`shmakes`).
+
+### GCP (`sshf-ui-prd`)
+
+- **APIs:** `run`, `cloudbuild`, `secretmanager`, `artifactregistry`, `iam`,
+  `iamcredentials`, `sts`
+- **Runtime SA** `sshf-ui-acc-prd`: `roles/secretmanager.secretAccessor`
+- **Deploy SA** `github-service-account`: `roles/run.admin`,
+  `roles/run.sourceDeveloper`, `roles/cloudbuild.builds.editor`,
+  `roles/serviceusage.serviceUsageConsumer`, `roles/iam.serviceAccountUser` on
+  the runtime SA (and on the Compute Engine default SA as needed for source
+  builds). Compute Engine default SA needs `roles/run.builder`.
+- **Secret:** `sshf-ui-google-client-secret-prd` (value loaded by an
+  administrator; never through agents or git)
+- **WIF:** pool `github-pool`, provider `sshf-ui`, attribute condition
+  `assertion.repository_owner_id == '189932599' && assertion.repository_id == '895307061'`
+
+### OAuth client (lives in `sshf-api-prd`)
+
+Prod UI and prod API share one OAuth web client. Authorized JavaScript origins
+must include `https://sshf-ui-824787296892.us-central1.run.app`. The UI uses a
+popup flow with `redirect_uri: 'postmessage'`, so no site redirect URI is
+required for the UI itself.
+
+When a custom domain (e.g. `db.starsandstripeshonorflight.org`) is added:
+
+1. Map the domain to the Cloud Run service.
+2. Add the origin to the OAuth client's Authorized JavaScript origins.
+3. Add the origin to the API's `ALLOWED_ORIGINS` (see sshf-api
+   `docs/DEPLOYMENT.md`).
+
+## First-time bootstrap (manual)
+
+Complete these before cutting the first production release:
+
+1. **OAuth origin** — In the sshf-api-prd console, open the prod OAuth Web
+   client and add Authorized JavaScript origin
+   `https://sshf-ui-824787296892.us-central1.run.app`. The UI uses a popup with
+   `redirect_uri: 'postmessage'` (no site redirect URI required).
+2. **Client secret** — Load the OAuth client secret into Secret Manager
+   (do this locally; never paste the value into chat):
+
+```powershell
+$secret = Read-Host -AsSecureString "GOOGLE_CLIENT_SECRET"
+$BSTR = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)
+$plain = [Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+$plain | gcloud secrets versions add sshf-ui-google-client-secret-prd `
+  --project=sshf-ui-prd --data-file=-
+[Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
+Remove-Variable plain, secret
+gcloud secrets versions list sshf-ui-google-client-secret-prd --project=sshf-ui-prd
+```
+
+3. **Merge** the prod-UI PR to `main` and confirm the **dev** deploy is green.
+4. **Release** `v1.0.0` and approve the `production` deployment as `shmakes`:
+
+```powershell
+gh release create v1.0.0 --target main --title "v1.0.0" --notes "First production UI deployment."
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Deploy fails at `check-build-env` | A `NEXT_PUBLIC_*` GitHub variable is missing or blank for that environment. |
+| Prod UI talks to the dev API | Build vars were wrong, or an old `.env.local` / fallback leaked into the build. Re-run the release workflow; confirm smoke-test grep passes. |
+| Release never asks for approval | The `production` GitHub environment or its required reviewer is missing. |
+| Auth step fails with a token/OIDC error | WIF provider, attribute condition, or SA binding was changed. |
+| Smoke test fails, traffic unchanged | New revision did not boot or bundle check failed. Check revision logs; users stay on the previous revision. |
+| Sign-in popup errors from Google | Prod UI origin missing from the OAuth client's Authorized JavaScript origins. |
+| CORS errors calling the API | Prod UI origin missing from the API's `ALLOWED_ORIGINS`. |
+| Tokens rejected by the API (401 audience) | UI and API must share the same OAuth client, or the UI client ID must be listed in the API's `ALLOWED_CLIENT_IDS`. |
+| New `GOOGLE_CLIENT_SECRET` not taking effect | Revisions pin secret versions at deploy time. Force a new revision / re-run release. |

--- a/docs/PROD_ENVIRONMENT_HANDOFF.md
+++ b/docs/PROD_ENVIRONMENT_HANDOFF.md
@@ -1,0 +1,213 @@
+# Handoff: Production Environment Setup for sshf-ui
+
+**Audience:** the AI agent (and supervising human) tasked with creating the
+production environment for sshf-ui, mirroring the completed sshf-api prod
+setup. Written 2026-07-25 at the end of the sshf-api session. All facts below
+were verified with read-only gcloud/gh commands on that date.
+
+## Mission
+
+Stand up `sshf-ui-prd` as a production environment sourced from `sshf-ui-dev`,
+with a release-gated CI/CD pipeline, mirroring the pattern established for
+sshf-api — **except where Next.js build-time configuration forces a different
+promotion strategy (see the Critical Difference section; read it before
+planning).**
+
+## Reference implementation (already completed for sshf-api)
+
+The sshf-api repo (`C:\Users\steve\Repos\sshf-api`) contains the working
+reference. Study these before writing anything:
+
+- `docs/DEPLOYMENT.md` — the full CI/CD design and rationale
+- `.github/workflows/cloudrun-source.yml` — dev deploy (v3 actions + SHA image tagging)
+- `.github/workflows/cloudrun-promote-prd.yml` — release-triggered promotion with approval gate
+
+Completed sshf-api prod resources (naming patterns to mirror):
+
+| Resource | Value |
+|---|---|
+| Runtime SA | `sshf-api-acc-prd@sshf-api-prd.iam.gserviceaccount.com` (only `secretmanager.secretAccessor`) |
+| Deploy SA | `github-service-account@sshf-api-prd.iam.gserviceaccount.com` (`run.admin`, `serviceAccountUser` on runtime SA, registry writer) |
+| WIF | pool `github-pool`, provider `sshf-api`, condition `assertion.repository_owner_id == '189932599' && assertion.repository_id == '<repo id>'` |
+| Registry | `us-central1-docker.pkg.dev/sshf-api-prd/sshf-api/sshf-api` (note: 4 path segments) |
+| Secrets | `sshf-api-*-prd` naming, values loaded by the user |
+| GitHub | `production` environment, required reviewer `shmakes`, env-scoped `GCP_*` secrets |
+| Versioning | semver git tags `vX.Y.Z` via GitHub Releases trigger promotion |
+
+## THE CRITICAL DIFFERENCE: Next.js build-time configuration
+
+sshf-ui is **Next.js 15** (Devias template). Verified facts:
+
+- `NEXT_PUBLIC_*` variables (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`,
+  `NEXT_PUBLIC_ROLE_FULL_ACCESS`, `NEXT_PUBLIC_SHOW_TEST_BANNER`) are **inlined
+  into the client JS bundle at `next build` time**. Evidence:
+  `src/lib/api.js:9`, `src/lib/auth/domain/client.js:6`, `src/config.js:13-18`,
+  and the dev workflow's own comment (`cloudrun-source.yml:67-68`).
+- `GOOGLE_CLIENT_SECRET` is server-side **runtime** config
+  (`src/app/api/auth/token/route.js:4-5`) — a genuine secret, never in the bundle.
+- There is **no runtime config endpoint** and no `next.config.*` in the repo.
+
+**Consequence:** a container image built with dev's `NEXT_PUBLIC_API_URL`
+serves dev's API URL forever. The sshf-api "build once, promote digest"
+pipeline CANNOT be copied as-is.
+
+Two options — present this decision to the user before implementing:
+
+1. **Per-environment build at release (recommended, lower risk).** Keep dev as
+   merge-to-main source deploy. For prod, the release-triggered workflow does a
+   **source deploy into `sshf-ui-prd`** from the tagged commit,
+   passing prod values as **build** env vars
+   (`--update-build-env-vars` / `.env.production`, the same mechanism the dev
+   workflow already uses for `NEXT_PUBLIC_SHOW_TEST_BANNER`). You lose
+   binary-identical promotion but keep the approval gate, versioned releases,
+   and prod isolation. Note `NEXT_PUBLIC_*` values are public by definition
+   (they ship in the bundle) — they are not secrets, even though dev stores
+   them in Secret Manager for convenience.
+2. **Refactor to runtime config first.** Serve environment config from the
+   Next.js server at request time (dynamic rendering or an `/api/config`
+   route), then digest promotion works like sshf-api. Larger code change,
+   test-first rules apply; only do this if the user opts in.
+
+Also verify during implementation: dev's Cloud Run service stores all five
+env vars as runtime `secretKeyRef`s, but client-visible values only work
+because they were present **at build time**. Do not assume the runtime refs
+are what the client bundle uses.
+
+## Verified current state (2026-07-25)
+
+### sshf-ui-dev (project number 593951006010)
+
+- Cloud Run service `sshf-ui`, us-central1, public (`allUsers` invoker),
+  1 CPU / 512Mi / timeout 300 / max 100, startup CPU boost.
+  URL: `https://sshf-ui-593951006010.us-central1.run.app`
+- Single SA `sshf-ui@sshf-ui-dev.iam.gserviceaccount.com` doubles as runtime
+  AND deploy identity, with over-broad roles (`artifactregistry.admin`,
+  `storage.admin`, `run.admin`, ...). **Do not replicate this in prod** — use
+  the sshf-api split (separate runtime + deploy SAs, least privilege).
+- Secrets: `sshf-ui-google-client-secret-dev`,
+  `sshf-ui-next-public-api-url-dev`, `sshf-ui-next-public-google-client-id-dev`,
+  `sshf-ui-next-public-role-full-access-dev`,
+  `sshf-ui-next-public-show-test-banner` (note: last one has no `-dev` suffix).
+- **No WIF pool in sshf-ui-dev** — the dev workflow authenticates against the
+  pool in `sshf-api-dev` (org-wide `repository_owner` condition). The new
+  prod pools are hardened per-repo, so `sshf-ui-prd` needs its **own** pool.
+- Registry: `cloud-run-source-deploy` (source deploys), images untagged.
+
+### sshf-ui-prd (project number 824787296892)
+
+Greenfield: only `roles/owner` for steve.schmechel; Cloud Run, Secret
+Manager, and Artifact Registry APIs disabled; no SAs, WIF, or repos.
+Deterministic prod URL will be: `https://sshf-ui-824787296892.us-central1.run.app`
+
+### Repo (`C:\Users\steve\Repos\sshf-ui`)
+
+- GitHub `Stars-and-Stripes-Honor-Flight/sshf-ui`, repo ID `895307061`,
+  owner ID `189932599`, default branch `main`.
+- Workflows: `cloudrun-source.yml` (merged PR → dev source deploy),
+  `run-tests.yml` (PR tests). Legacy GCS scripts `deploy.ps1`/`deploy.sh`
+  exist — likely obsolete; ask the user before touching.
+- `package.json` version is `7.2.1` (leftover Devias template versioning) and
+  the name is still `@devias-kit-pro/nextjs-template`. Ask the user what the
+  first prod release tag should be (fresh `v1.0.0` recommended).
+- Hardcoded dev URLs exist: `src/lib/api.js:9` (dev API fallback — must not
+  leak into a prod build; always set `NEXT_PUBLIC_API_URL` at build time),
+  `scripts/resolve-openapi-url.mjs:3`, `docs/openapi.json`.
+- `.cursor/rules/` exists (10 files incl. `test-first-planning.mdc`) — the
+  same plan-first/test-first and secrets-hygiene rules apply in that repo.
+
+## Coordination facts with the completed sshf-api prod
+
+- Prod API URL: `https://sshf-api-928260206537.us-central1.run.app`
+  → this is prod's `NEXT_PUBLIC_API_URL`.
+- The prod API's `ALLOWED_ORIGINS` **already includes**
+  `https://sshf-ui-824787296892.us-central1.run.app` — no API-side CORS change
+  needed for the UI's Cloud Run URL. When the custom domain
+  (`db.starsandstripeshonorflight.org` or similar) arrives, it must be added
+  to the API's `ALLOWED_ORIGINS` and the OAuth client.
+- The user created a **prod OAuth client** (stored in the API project's
+  `sshf-api-auth-clientid-prd`). The UI should use the SAME client:
+  its ID becomes `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, and its **client secret**
+  goes into a new `sshf-ui-google-client-secret-prd`. The client's authorized
+  JavaScript origins and redirect URIs must include the prod UI URL — user
+  action in the `sshf-api-prd` console.
+- `NEXT_PUBLIC_ROLE_FULL_ACCESS`: the Workspace group
+  `sshf_app_prd_full_access@starsandstripeshonorflight.org` exists (verified);
+  confirm with the user that this is the prod value.
+- `NEXT_PUBLIC_SHOW_TEST_BANNER` should be `false`/absent for prod (confirm).
+- No Admin SDK / Workspace access needed for the UI's runtime SA — group
+  checks happen in the API, not the UI (verified: UI server routes only do
+  OAuth token exchange).
+
+## Suggested execution order
+
+1. Confirm the promotion-strategy decision (Option 1 vs 2 above) with the user.
+2. Enable APIs on `sshf-ui-prd`: `run`, `secretmanager`, `artifactregistry`,
+   `iam`, `iamcredentials`, `sts` — **plus `cloudbuild` if Option 1 (prod
+   source builds)**. Admin SDK not needed.
+3. Create SAs: `sshf-ui-acc-prd` (runtime; `secretmanager.secretAccessor`) and
+   `github-service-account` (deploy; `run.admin`, `serviceAccountUser` on
+   runtime SA; for Option 1 add the source-deploy roles Cloud Build needs —
+   check `run.sourceDeveloper`/`cloudbuild.builds.editor` against current docs).
+4. Create secrets (containers only; user loads values):
+   `sshf-ui-google-client-secret-prd`, `sshf-ui-next-public-api-url-prd`,
+   `sshf-ui-next-public-google-client-id-prd`,
+   `sshf-ui-next-public-role-full-access-prd`,
+   `sshf-ui-next-public-show-test-banner-prd`.
+5. WIF: pool `github-pool` + OIDC provider `sshf-ui` in `sshf-ui-prd`, with
+   condition `assertion.repository_owner_id == '189932599' &&
+   assertion.repository_id == '895307061'`; bind `workloadIdentityUser` for
+   the repo principalSet to the deploy SA.
+6. GitHub: `production` environment on sshf-ui repo (required reviewer
+   `shmakes`, user ID 686667) + env secrets `GCP_PROJECT_ID=sshf-ui-prd`,
+   `GCP_SERVICE_NAME=sshf-ui`, `GCP_REGION=us-central1`,
+   `GCP_WORKLOAD_IDENTITY_PROVIDER=projects/824787296892/locations/global/workloadIdentityPools/github-pool/providers/sshf-ui`,
+   `GCP_SERVICE_ACCOUNT=github-service-account@sshf-ui-prd.iam.gserviceaccount.com`.
+   The gh CLI is authenticated as `shmakes` and can do all of this.
+7. Release workflow + bootstrap deploy + smoke test, then documentation
+   (mirror `docs/DEPLOYMENT.md`, adjusted for the chosen build strategy).
+
+## Lessons learned in the sshf-api session (read before running commands)
+
+- **Check before creating.** The user pre-created some resources (runtime SA,
+  all secrets with values). Expect "already exists" conflicts; treat them as
+  discoveries, not errors. Check secret values exist with
+  `gcloud secrets versions list <name>` — NEVER `versions access`.
+- **Artifact Registry paths have four segments**:
+  `HOST/PROJECT/REPOSITORY/IMAGE`. `.../sshf-ui-prd/sshf-ui` is a repository,
+  not an image — pushing to it fails with `NAME_INVALID`.
+- **Cloud Run URLs are deterministic**: `https://<service>-<project-number>.<region>.run.app`.
+  You can configure OAuth clients and env values before the first deploy.
+- **PowerShell quoting bites**: gcloud `--format` strings containing spaces
+  after commas and `gh --jq` expressions with spaces get mangled. Use simple
+  `value(...)` formats, single-quoted compact jq, and the `"^;^KEY=a,b,c"`
+  delimiter syntax for comma-containing `--set-env-vars` values.
+- **Cloud mutations trigger approval cards** (Cursor auto-review). Retry the
+  exact same command with the approval mechanism; the card UI occasionally
+  errors ("Could not find bubble") — just retry. Batch related IAM bindings
+  into one command to reduce approval round-trips.
+- **Secrets hygiene**: create secret containers only; the user loads values.
+  Never print tokens, secret values, or pipe them through command args (use
+  `--password-stdin` / PowerShell variables).
+- **Missing enabled APIs fail silently downstream.** sshf-api's group lookups
+  returned empty because `admin.googleapis.com` wasn't enabled in prod and the
+  app swallowed the 403. For the UI, the analogous risk is a prod build
+  succeeding with a missing `NEXT_PUBLIC_API_URL` and silently baking in the
+  dev fallback URL from `src/lib/api.js:9` — add a build-time guard or verify
+  the bundle after the first deploy.
+- **Verify by read-back.** After each provisioning phase, list/describe what
+  was created. After deploy, smoke test: the UI should return 200 on `/` and
+  the sign-in flow should reach Google with the prod client ID.
+- The sshf-api dev deploy workflow was upgraded to `google-github-actions/*@v3`
+  actions — do the same for sshf-ui while touching its workflows.
+
+## User manual steps to schedule (small list)
+
+1. OAuth client (in `sshf-api-prd` console): add the prod UI origin
+   `https://sshf-ui-824787296892.us-central1.run.app` to authorized JavaScript
+   origins and the appropriate redirect URI(s) used by the UI's auth flow
+   (check `src/lib/auth/domain/` for the exact callback path).
+2. Load the five `-prd` secret values (client secret, API URL, client ID,
+   full-access role group, test banner flag).
+3. Approve the GitHub production deployments.
+4. Later: custom domain mapping + adding it to OAuth origins and the API's
+   `ALLOWED_ORIGINS`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@devias-kit-pro/nextjs-template",
   "author": "Devias IO",
-  "version": "7.2.1",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,6 +15,7 @@
     "format:check": "prettier --check \"**/*.{js,jsx,mjs,ts,tsx,mdx}\" --cache",
     "test": "jest",
     "test:watch": "jest --watch",
+    "check-build-env": "node scripts/check-build-env.mjs",
     "sync-schemas": "node scripts/sync-schemas.mjs",
     "sync-schemas:local": "node scripts/sync-schemas.mjs --local",
     "generate-schemas": "orval --config orval.config.mjs"

--- a/scripts/__tests__/check-build-env.test.js
+++ b/scripts/__tests__/check-build-env.test.js
@@ -1,0 +1,46 @@
+import { REQUIRED_BUILD_ENV_VARS, findMissingBuildEnvVars } from '../check-build-env.mjs';
+
+describe('check-build-env', () => {
+  test('requires the four client build variables', () => {
+    expect(REQUIRED_BUILD_ENV_VARS).toEqual([
+      'NEXT_PUBLIC_API_URL',
+      'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
+      'NEXT_PUBLIC_ROLE_FULL_ACCESS',
+      'NEXT_PUBLIC_ENVIRONMENT',
+    ]);
+  });
+
+  test('returns an empty list when every variable is set', () => {
+    const env = {
+      NEXT_PUBLIC_API_URL: 'https://api.example.test',
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: 'client-id.apps.googleusercontent.com',
+      NEXT_PUBLIC_ROLE_FULL_ACCESS: 'group@example.test',
+      NEXT_PUBLIC_ENVIRONMENT: 'Production',
+    };
+    expect(findMissingBuildEnvVars(env)).toEqual([]);
+  });
+
+  test('reports unset variables', () => {
+    const env = {
+      NEXT_PUBLIC_API_URL: 'https://api.example.test',
+      NEXT_PUBLIC_ENVIRONMENT: 'Production',
+    };
+    expect(findMissingBuildEnvVars(env)).toEqual([
+      'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
+      'NEXT_PUBLIC_ROLE_FULL_ACCESS',
+    ]);
+  });
+
+  test('treats blank values as missing', () => {
+    const env = {
+      NEXT_PUBLIC_API_URL: '   ',
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: '',
+      NEXT_PUBLIC_ROLE_FULL_ACCESS: 'group@example.test',
+      NEXT_PUBLIC_ENVIRONMENT: 'Production',
+    };
+    expect(findMissingBuildEnvVars(env)).toEqual([
+      'NEXT_PUBLIC_API_URL',
+      'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
+    ]);
+  });
+});

--- a/scripts/check-build-env.mjs
+++ b/scripts/check-build-env.mjs
@@ -1,0 +1,34 @@
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Client build variables that must be present when building a deployable
+ * bundle. NEXT_PUBLIC_* values are inlined at `next build` time, so a missing
+ * value silently ships a broken (or wrong-environment) bundle. CI runs this
+ * script before deploying; it fails the build if anything is unset.
+ */
+export const REQUIRED_BUILD_ENV_VARS = [
+  'NEXT_PUBLIC_API_URL',
+  'NEXT_PUBLIC_GOOGLE_CLIENT_ID',
+  'NEXT_PUBLIC_ROLE_FULL_ACCESS',
+  'NEXT_PUBLIC_ENVIRONMENT',
+];
+
+/**
+ * @param {Record<string, string | undefined>} env
+ * @returns {string[]} names of required variables that are unset or blank
+ */
+export function findMissingBuildEnvVars(env = process.env) {
+  return REQUIRED_BUILD_ENV_VARS.filter((name) => !(env[name] || '').trim());
+}
+
+const isRunDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isRunDirectly) {
+  const missing = findMissingBuildEnvVars();
+  if (missing.length > 0) {
+    console.error(`Missing required build environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+  console.log('All required build environment variables are set.');
+}

--- a/src/components/auth/domain/__tests__/sign-in-form.test.js
+++ b/src/components/auth/domain/__tests__/sign-in-form.test.js
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { SignInForm } from '../sign-in-form';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/hooks/use-user', () => ({
+  useUser: () => ({ checkSession: jest.fn() }),
+}));
+
+jest.mock('@/lib/auth/domain/client', () => ({
+  authClient: { signInWithOAuth: jest.fn() },
+}));
+
+jest.mock('@/components/core/toaster', () => ({
+  toast: { error: jest.fn(), success: jest.fn() },
+}));
+
+jest.mock('@/components/core/logo', () => ({
+  DynamicLogo: () => null,
+}));
+
+describe('SignInForm environment banner', () => {
+  const originalEnvironment = process.env.NEXT_PUBLIC_ENVIRONMENT;
+
+  afterEach(() => {
+    if (originalEnvironment === undefined) {
+      delete process.env.NEXT_PUBLIC_ENVIRONMENT;
+    } else {
+      process.env.NEXT_PUBLIC_ENVIRONMENT = originalEnvironment;
+    }
+  });
+
+  test('shows the environment name in the banner for non-production environments', async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Development';
+
+    render(<SignInForm />);
+
+    expect(await screen.findByText(/DEVELOPMENT ENVIRONMENT/)).toBeInTheDocument();
+  });
+
+  test('hides the banner in the Production environment', async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Production';
+
+    render(<SignInForm />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/ENVIRONMENT/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/auth/domain/sign-in-form.js
+++ b/src/components/auth/domain/sign-in-form.js
@@ -16,6 +16,7 @@ import { Warning } from '@phosphor-icons/react';
 
 import { paths } from '@/paths';
 import { authClient } from '@/lib/auth/domain/client';
+import { getEnvironmentBanner } from '@/lib/environment';
 import { useUser } from '@/hooks/use-user';
 import { DynamicLogo } from '@/components/core/logo';
 import { toast } from '@/components/core/toaster';
@@ -28,13 +29,12 @@ export function SignInForm() {
   const router = useRouter();
   const { checkSession } = useUser();
   const [isPending, setIsPending] = React.useState(false);
-  const [isTestEnvironment, setIsTestEnvironment] = React.useState(false);
-  
-  // Show test environment indicator if NODE_ENV is not production or if explicitly set
-  // Only check on client side to avoid hydration mismatches
+  const [environmentBanner, setEnvironmentBanner] = React.useState(null);
+
+  // Banner shows for any non-production NEXT_PUBLIC_ENVIRONMENT.
+  // Only check on client side to avoid hydration mismatches.
   React.useEffect(() => {
-    const isTest = process.env.NODE_ENV !== 'production' || process.env.NEXT_PUBLIC_SHOW_TEST_BANNER === 'true';
-    setIsTestEnvironment(isTest);
+    setEnvironmentBanner(getEnvironmentBanner());
   }, []);
 
   const onAuth = React.useCallback(async (providerId) => {
@@ -78,7 +78,7 @@ export function SignInForm() {
         </Box>
       </div>
       <Stack spacing={3}>
-        {isTestEnvironment && (
+        {environmentBanner?.show && (
           <Box
             sx={{
               display: 'flex',
@@ -133,7 +133,7 @@ export function SignInForm() {
                 whiteSpace: 'nowrap',
               }}
             >
-              🧪 TEST ENVIRONMENT
+              🧪 {environmentBanner?.label}
             </Box>
           </Box>
         )}

--- a/src/components/main/layout/vertical/__tests__/main-nav.test.js
+++ b/src/components/main/layout/vertical/__tests__/main-nav.test.js
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { MainNav } from '../main-nav';
+
+jest.mock('@/hooks/use-user', () => ({
+  useUser: () => ({ user: { avatar: null } }),
+}));
+
+jest.mock('@/components/main/layout/mobile-nav', () => ({
+  MobileNav: () => null,
+}));
+
+jest.mock('@/components/main/layout/user-popover/user-popover', () => ({
+  UserPopover: () => null,
+}));
+
+describe('MainNav environment banner', () => {
+  const originalEnvironment = process.env.NEXT_PUBLIC_ENVIRONMENT;
+
+  afterEach(() => {
+    if (originalEnvironment === undefined) {
+      delete process.env.NEXT_PUBLIC_ENVIRONMENT;
+    } else {
+      process.env.NEXT_PUBLIC_ENVIRONMENT = originalEnvironment;
+    }
+  });
+
+  test('shows the environment name in the banner for non-production environments', async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Development';
+
+    render(<MainNav items={[]} />);
+
+    expect(await screen.findByText(/DEVELOPMENT ENVIRONMENT/)).toBeInTheDocument();
+  });
+
+  test('hides the banner in the Production environment', async () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Production';
+
+    render(<MainNav items={[]} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/ENVIRONMENT/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/main/layout/vertical/main-nav.js
+++ b/src/components/main/layout/vertical/main-nav.js
@@ -14,6 +14,7 @@ import { Warning } from '@phosphor-icons/react';
 
 import { usePopover } from '@/hooks/use-popover';
 import { useUser } from '@/hooks/use-user';
+import { getEnvironmentBanner } from '@/lib/environment';
 
 import { MobileNav } from '../mobile-nav';
 import { UserPopover } from '../user-popover/user-popover';
@@ -21,13 +22,12 @@ import { UserPopover } from '../user-popover/user-popover';
 export function MainNav({ items }) {
   const [openNav, setOpenNav] = React.useState(false);
   const { user } = useUser();
-  const [isTestEnvironment, setIsTestEnvironment] = React.useState(false);
-  
-  // Show test environment indicator if NODE_ENV is not production or if explicitly set
-  // Only check on client side to avoid hydration mismatches
+  const [environmentBanner, setEnvironmentBanner] = React.useState(null);
+
+  // Banner shows for any non-production NEXT_PUBLIC_ENVIRONMENT.
+  // Only check on client side to avoid hydration mismatches.
   React.useEffect(() => {
-    const isTest = process.env.NODE_ENV !== 'production' || process.env.NEXT_PUBLIC_SHOW_TEST_BANNER === 'true';
-    setIsTestEnvironment(isTest);
+    setEnvironmentBanner(getEnvironmentBanner());
   }, []);
 
   return (
@@ -57,7 +57,7 @@ export function MainNav({ items }) {
             position: 'relative',
           }}
         >
-          {isTestEnvironment ? (
+          {environmentBanner?.show ? (
             <>
               {/* Mobile menu button - positioned absolutely on the left */}
               <IconButton
@@ -130,7 +130,7 @@ export function MainNav({ items }) {
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  🧪 TEST ENVIRONMENT
+                  🧪 {environmentBanner?.label}
                 </Box>
               </Box>
               

--- a/src/lib/__tests__/api-base-url.test.js
+++ b/src/lib/__tests__/api-base-url.test.js
@@ -1,0 +1,47 @@
+jest.mock('@/components/core/toaster', () => ({
+  toast: { error: jest.fn() },
+}));
+
+jest.mock('@/lib/auth/domain/tokenManager', () => ({
+  tokenManager: {
+    getValidToken: jest.fn(),
+    getRefreshToken: jest.fn(),
+    refreshToken: jest.fn(),
+    clearTokens: jest.fn(),
+  },
+}));
+
+describe('ApiClient base URL', () => {
+  const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  afterEach(() => {
+    if (originalApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+    }
+    jest.resetModules();
+  });
+
+  test('uses NEXT_PUBLIC_API_URL when set', () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.test';
+
+    let api;
+    jest.isolateModules(() => {
+      api = require('@/lib/api').api;
+    });
+
+    expect(api.baseUrl).toBe('https://api.example.test');
+  });
+
+  test('does not silently fall back to the dev API URL when unset', () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+
+    let api;
+    jest.isolateModules(() => {
+      api = require('@/lib/api').api;
+    });
+
+    expect(api.baseUrl).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/environment.test.js
+++ b/src/lib/__tests__/environment.test.js
@@ -1,0 +1,44 @@
+import { getEnvironmentBanner } from '@/lib/environment';
+
+describe('getEnvironmentBanner', () => {
+  const originalEnvironment = process.env.NEXT_PUBLIC_ENVIRONMENT;
+
+  afterEach(() => {
+    if (originalEnvironment === undefined) {
+      delete process.env.NEXT_PUBLIC_ENVIRONMENT;
+    } else {
+      process.env.NEXT_PUBLIC_ENVIRONMENT = originalEnvironment;
+    }
+  });
+
+  test('hides the banner when the environment is Production', () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Production';
+    expect(getEnvironmentBanner().show).toBe(false);
+  });
+
+  test('hides the banner regardless of Production casing', () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'production';
+    expect(getEnvironmentBanner().show).toBe(false);
+  });
+
+  test('shows the banner with the environment name for non-production environments', () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = 'Development';
+    const banner = getEnvironmentBanner();
+    expect(banner.show).toBe(true);
+    expect(banner.label).toBe('DEVELOPMENT ENVIRONMENT');
+  });
+
+  test('shows a generic test banner when the environment is unset', () => {
+    delete process.env.NEXT_PUBLIC_ENVIRONMENT;
+    const banner = getEnvironmentBanner();
+    expect(banner.show).toBe(true);
+    expect(banner.label).toBe('TEST ENVIRONMENT');
+  });
+
+  test('shows a generic test banner when the environment is blank', () => {
+    process.env.NEXT_PUBLIC_ENVIRONMENT = '   ';
+    const banner = getEnvironmentBanner();
+    expect(banner.show).toBe(true);
+    expect(banner.label).toBe('TEST ENVIRONMENT');
+  });
+});

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,7 +6,10 @@ import { paths } from '@/paths';
 
 class ApiClient {
   constructor() {
-    this.baseUrl = process.env.NEXT_PUBLIC_API_URL || 'https://sshf-api-330507742215.us-central1.run.app';
+    // No fallback: a missing NEXT_PUBLIC_API_URL must fail loudly rather than
+    // silently pointing a build at the wrong environment's API.
+    // CI enforces this via scripts/check-build-env.mjs before deploying.
+    this.baseUrl = process.env.NEXT_PUBLIC_API_URL;
   }
 
   // Handle unauthorized errors by clearing tokens and redirecting to login

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -1,0 +1,12 @@
+// Environment identity for the client bundle. NEXT_PUBLIC_ENVIRONMENT is
+// inlined at build time (e.g. "Development", "Production"); anything other
+// than Production shows the warning banner so non-prod deployments are obvious.
+export function getEnvironmentBanner() {
+  const environment = (process.env.NEXT_PUBLIC_ENVIRONMENT || '').trim();
+  const isProduction = environment.toLowerCase() === 'production';
+
+  return {
+    show: !isProduction,
+    label: `${(environment || 'Test').toUpperCase()} ENVIRONMENT`,
+  };
+}


### PR DESCRIPTION
﻿## Summary
- Add a release-gated Cloud Run source-deploy pipeline for `sshf-ui-prd`, with `NEXT_PUBLIC_*` values supplied via GitHub Environment variables (replacing checked-in `.env.local`).
- Drive the non-prod warning banner from `NEXT_PUBLIC_ENVIRONMENT` and fail CI builds that are missing required client build vars.
- Document the prod UI deployment model in `docs/DEPLOYMENT.md` (source-build per environment, because Next.js inlines `NEXT_PUBLIC_*` at build time).

Closes #94

## Test plan
- [ ] `npx jest` focused suites for environment banner, API base URL, and `check-build-env` pass
- [ ] After merge, confirm **dev** deploy succeeds and shows the DEVELOPMENT banner
- [ ] Confirm GitHub `production` environment requires reviewer approval
- [ ] Cut `v1.0.0`, approve the production deployment, and verify https://sshf-ui-824787296892.us-central1.run.app has no banner and signs in against the prod API
