### PR TITLE
Grant Cloud Run public invoker before the smoke test

### DIFF
--- a/.github/workflows/cloudrun-release-prd.yml
+++ b/.github/workflows/cloudrun-release-prd.yml
@@ -160,6 +160,15 @@ jobs:
           echo "url=$SMOKE_URL" >> "$GITHUB_OUTPUT"
           echo "Smoke URL: $SMOKE_URL"
 
+      # Must run before the unauthenticated smoke test. New services are private
+      # until allUsers is granted roles/run.invoker (same posture as sshf-ui-dev).
+      - name: 'Ensure public invoker'
+        run: |
+          gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
+            --region "${REGION}" --project "${PROJECT_ID}" \
+            --member="allUsers" --role="roles/run.invoker" \
+            --quiet
+
       - name: 'Smoke test revision'
         run: |
           SMOKE_URL="${{ steps.smoke_url.outputs.url }}"
@@ -203,14 +212,6 @@ jobs:
         run: |
           gcloud run services update-traffic "${SERVICE_NAME}" \
             --region "${REGION}" --project "${PROJECT_ID}" --to-latest
-
-      # Idempotent: required for the first bootstrap deploy; harmless afterward.
-      - name: 'Ensure public invoker'
-        run: |
-          gcloud run services add-iam-policy-binding "${SERVICE_NAME}" \
-            --region "${REGION}" --project "${PROJECT_ID}" \
-            --member="allUsers" --role="roles/run.invoker" \
-            --quiet
 
       - name: 'Show output'
         run: |-


### PR DESCRIPTION
﻿## Summary
- The production service was created private by default, so the unauthenticated smoke test (and browser) got `403 Forbidden`.
- Grant `roles/run.invoker` to `allUsers` **before** the smoke test (idempotent; same public posture as `sshf-ui-dev`).
- Public invoker was also applied directly on the existing `sshf-ui` service in `sshf-ui-prd` so https://sshf-ui-824787296892.us-central1.run.app/ already returns HTTP 200.

## Test plan
- [x] Merge to `main`
- [x] Re-run **Release to Cloud Run Production** from `main` with version `v1.0.0`
- [x] Confirm smoke test passes and the workflow completes green
- [x] Confirm https://sshf-ui-824787296892.us-central1.run.app/ loads and sign-in works against the prod API
